### PR TITLE
[major] Harden the Vault Cloud Run boundary

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,36 @@
+.PHONY: actionlint check docs docs-check fmt fmt-check init test tflint validate
+
+TERRAFORM ?= terraform
+TERRAFORM_DOCS ?= terraform-docs
+TFLINT ?= tflint
+ACTIONLINT ?= actionlint
+
+fmt:
+	$(TERRAFORM) fmt -recursive .
+
+fmt-check:
+	$(TERRAFORM) fmt -check -recursive .
+
+init:
+	$(TERRAFORM) init -backend=false -input=false
+
+validate: init
+	$(TERRAFORM) validate
+
+test: init
+	$(TERRAFORM) test
+
+tflint:
+	$(TFLINT) --init
+	$(TFLINT) --recursive
+
+actionlint:
+	$(ACTIONLINT)
+
+docs:
+	$(TERRAFORM_DOCS) markdown table --lockfile=false --output-file README.md .
+
+docs-check:
+	$(TERRAFORM_DOCS) markdown table --lockfile=false --output-check --output-file README.md .
+
+check: fmt-check validate test tflint actionlint docs-check

--- a/README.md
+++ b/README.md
@@ -1,140 +1,196 @@
 # terraform-vault-cloudrun
 
-Fork of [kelseyhightower/serverless-vault-with-cloud-run](https://github.com/kelseyhightower/serverless-vault-with-cloud-run), reimagined as a terraform module to deploy Vault using Google Cloud Run.
+This Terraform module deploys a single-instance Vault service on Google Cloud
+Run with a public Vault Proxy v2 sidecar and a one-shot initializer job. It is a
+fork of
+[kelseyhightower/serverless-vault-with-cloud-run](https://github.com/kelseyhightower/serverless-vault-with-cloud-run)
+with explicit workload identities, immutable image inputs, and recovery
+material isolated from the long-running Vault process.
 
+## Security model
+
+The module creates two service accounts with separate responsibilities:
+
+- The Vault runtime can administer objects only in the Vault data bucket and
+  view, encrypt, or decrypt with the configured KMS key. Vault's `gcpckms`
+  auto-unseal integration needs `cryptoKeys.get` in addition to cryptographic
+  operations.
+- The initializer can create and view objects only in the recovery bucket and
+  encrypt or decrypt with the same KMS key. It cannot delete or overwrite
+  recovery objects.
+
+Cloud Run assigns one service identity to the whole multi-container revision.
+The co-located proxy therefore inherits the runtime account's GCS and KMS
+credentials even though the proxy does not use them. The runtime permissions
+are intentionally limited, but this remains a trust boundary: promote the Vault
+and proxy images as one reviewed unit.
+
+Vault Proxy v2 permits unauthenticated access only to canonical route patterns
+in `public_routes`. Every other route requires an `X-Admin-Token` Google access
+token whose verified email is either explicitly listed in `admin_emails` or is
+the initializer service account. The Vault runtime service account is not a
+proxy administrator. Email comparisons and duplicate checks are
+case-insensitive to match Vault Proxy's identity normalization.
+
+The Cloud Run service remains publicly invokable because Vault Proxy is its
+application-layer boundary. Vault still enforces its own tokens and policies
+after the proxy check.
+
+The Vault container starts first and must pass its port-specific health probe
+on `8200` before Cloud Run starts the dependent proxy container. The proxy then
+passes its own `/healthz` probe on `8080` before the revision can receive
+traffic. The Vault health probe treats an uninitialized server as ready so the
+initializer job can complete the first deployment.
+
+## Prerequisites
+
+Enable these APIs in the target project before using the module:
+
+- Cloud Run API
+- Cloud Key Management Service API
+- Cloud Storage API
+- Identity and Access Management API
+
+Because Terraform creates and immediately executes the initializer, the
+applying identity also needs permission to run that Cloud Run job in addition
+to its resource-management permissions.
+
+The caller must supply three
+[Artifact Registry](https://cloud.google.com/artifact-registry/docs/docker/names)
+image references pinned by manifest digest:
+
+- Vault server
+- Vault Proxy v2
+- Vault initializer
+
+The module intentionally has no mutable image defaults. Review and promote the
+three GAR digests together before changing a deployment.
+
+The initializer job uses the `google-beta` provider only because Cloud Run's
+Terraform `run_execution_token` remains absent from the stable provider. Every
+other resource uses the stable `google` provider. This keeps initialization
+Terraform-managed and makes `terraform apply` wait for successful completion,
+without introducing a credentialed `local-exec` or manual deployment step.
 
 ## Usage
 
-In your existing terraform code, add something like what's seen in [the example](./example)
+```hcl
+module "vault" {
+  source = "git::https://github.com/libops/terraform-vault-cloudrun.git?ref=1.0.0"
 
-The GCP project needs the following non-standard APIs enabled:
+  project = "example-project"
+  region  = "us-central1"
 
-- Cloud Run API
-- Google Cloud KMS API
-- Identity and Access Management (IAM) API
+  vault_image = "us-docker.pkg.dev/example-project/public/vault@sha256:REVIEWED_DIGEST"
+  vault_proxy_image = "us-docker.pkg.dev/example-project/public/vault-proxy@sha256:REVIEWED_DIGEST"
+  vault_init_image  = "us-docker.pkg.dev/example-project/public/vault-init@sha256:REVIEWED_DIGEST"
 
-## After terraform apply
+  admin_emails = [
+    "vault-admin@example.org",
+  ]
+}
+```
 
-![Serverless Vault Architecture](serverless-vault.png)
+`deletion_protection` defaults to `true` for both the service and initializer
+job. Set it to `false` and apply that change before intentionally destroying
+the deployment.
 
-After this module has been ran, the Vault server is up and running and has been initialized. The root token is encrypted in a GCS bucket.
+## Initialization behavior
 
-Pass a pinned `vault_image` digest to deploy the Vault server container. The
-module no longer builds or pushes Docker images during Terraform runs, so it
-can run from Cloud Run jobs and other environments without Docker daemon access.
-The included Dockerfile builds the independently released, multi-platform
-`vault-server` image. It checks out the exact upstream Vault 2.0.3 commit and
-rebuilds the official UI-enabled target with a digest-pinned patched Go
-toolchain before copying only the binary and license into the runtime. This
-avoids inheriting vulnerabilities from an older upstream compiler while
-preserving the reviewed Vault source identity. The runtime uses a numeric
-non-root identity and renders its seal config at startup from the
-`KMS_KEY_RING` and `KMS_CRYPTO_KEY` environment variables.
+The initializer has one task, parallelism one, three retries, and a ten-minute
+task timeout. `CHECK_INTERVAL=0s` makes every task a bounded one-shot attempt.
+Its 31-character `run_execution_token` is a deterministic SHA-256 prefix over
+the three image digests, service and identity settings, bucket and KMS IDs,
+proxy policy, startup contract, and initializer job settings. A relevant
+deployment change therefore runs the idempotent initializer verification
+again and keeps the apply open until that execution succeeds. Provider create
+and update timeouts allow all bounded retries to finish. Change
+`initializer_execution_nonce` when an operator needs to request the same
+verification without otherwise changing the deployment.
 
-The GCS backend enables its HA lock as a fencing boundary. The Cloud Run module
-normally caps the service at one instance, but Cloud Run can briefly overlap
-revisions or exceed a configured maximum. The lock prevents two Vault servers
-from becoming active against the same backend. Clustering remains disabled
-because Cloud Run services cannot address an individual instance's cluster
-listener; this is storage safety, not a highly available serving topology.
+`init_job_name` is limited to 30 characters so the job name, separator, and
+31-character execution suffix remain inside Cloud Run's execution-name limit.
 
-Image publication is intentionally separate from module releases and ordinary
-API image bundles. A change to the Dockerfile, entrypoint, config template, or
-image workflow is built and scanned without credentials in pull requests. Once
-the exact commit passes the protected main CI workflow, the shared LibOps image
-publisher signs the same multi-platform manifest in GHCR and
-`us-docker.pkg.dev/libops-images/public`. Image tags include the upstream Vault
-version, the LibOps packaging revision, the exact source commit, and the
-publication run. Every publication therefore receives a unique tag;
-deployments must still use the verified digest.
+Vault Init authenticates protected health and initialization routes as the
+initializer service account. The selected Vault Init image must request a
+Google metadata access token containing the `userinfo.email` scope expected by
+Vault Proxy v2.
+
+Encrypted recovery material is stored in `recovery_bucket_name`. Treat access
+to that bucket and the KMS key as privileged disaster-recovery access. Do not
+copy the decrypted root token into Terraform state or CI logs.
+
+## Public route policy
+
+The defaults expose the minimum OIDC discovery, OIDC callback, and userpass
+login paths used by common clients. `/v1/sys/health` is always added even when
+`public_routes` is empty. Vault Proxy v2 path patterns are explicit:
+
+- A literal path matches exactly.
+- `*` matches one path segment.
+- A final `/**` matches a subtree.
+
+Legacy trailing-slash prefixes such as `/v1/auth/userpass/` are rejected. Add a
+secret-engine subtree only when Vault policy is intentionally the sole
+authorization boundary for that path.
+
+## Networking
+
+Direct VPC egress is deliberately `OFF` and is not exposed as a module input.
+This deployment uses Google APIs and the public Cloud Run service URL, so it
+does not need a Serverless VPC Access connector or Direct VPC attachment.
+Keeping networking outside this module also avoids silently expanding the
+Vault trust boundary. A platform that requires private egress should compose
+and review that network path separately rather than enabling it implicitly
+here.
+
+## Availability and revisions
+
+This is a single-serving-instance Vault deployment, not an HA failover
+topology. The pinned Cloud Run module applies a service-level maximum of one
+across traffic-serving revisions. Because Cloud Run can still briefly exceed a
+configured maximum during rollout, the GCS backend enables its HA lock to fence
+overlapping revisions so only one Vault server becomes active. Clustering stays
+disabled because Cloud Run services cannot address individual instance cluster
+listeners. Revision changes can therefore cause transient request failures;
+quiesce clients and use a maintenance window.
+
+## Local development image
+
+The repository Dockerfile is a development-only way to exercise the included
+Vault configuration template. Terraform never builds it and it is not a
+default image source. Production callers must supply a reviewed,
+digest-pinned GAR image through `vault_image`.
+
+## Upgrade
+
+Version 1 changes identities, IAM, image inputs, proxy routes, and initialization
+behavior. Read [UPGRADING.md](UPGRADING.md) and review the full Terraform plan
+before applying it to an existing Vault deployment.
+
+## Vault server image publication
+
+Terraform never builds or pushes images. The repository Dockerfile is the
+reviewed source for the independently released, multi-platform `vault-server`
+image. It checks out the exact upstream Vault 2.0.3 commit, rebuilds the
+UI-enabled target with a digest-pinned patched Go toolchain, and copies only the
+binary and license into a numeric non-root runtime. The entrypoint renders the
+seal configuration from `KMS_KEY_RING` and `KMS_CRYPTO_KEY` at startup.
+
+Image pull requests build and scan both native architectures without publisher
+credentials. After the exact commit passes protected `main` CI, the shared
+LibOps workflow publishes, scans, signs, and verifies the same multi-platform
+manifest in GHCR and `us-docker.pkg.dev/libops-images/public`. Its unique tag
+records the upstream version, LibOps packaging revision, source commit, and
+workflow run. Deployments must still resolve and use the verified GAR digest.
 
 Image payload pull requests and image-trust-only pull requests must retain
-`[skip-release]` in the title, including after title edits, so they cannot cut a
-Terraform module release. A pull request that changes both module payload and
-image trust must carry an explicit release marker. The release workflow also
-classifies the merged PR file list and suppresses unmarked image/trust-only
-changes, so the title marker is not the sole enforcement boundary. Completed CI
-runs that are not a successful push from this repository's current `main`
-branch are treated as intentional publication no-ops.
-
-The `Terraform CI` workflow at `.github/workflows/lint-test.yml` is part of the
-publisher identity and event trust boundary. Keep its name, path, protected-main
-push trigger, and image-contract validation synchronized with the image
-workflow and shared WIF configuration.
-
-If you list the GCS storage bucket you will see a new set of directories created by Vault:
-
-```
-$ gsutil ls gs://${TF_VAR_project}-data
-
-gs://XXXXXX-data/core/
-gs://XXXXXX-data/logical/
-gs://XXXXXX-data/sys/
-```
-
-Vault can be configured using the [Vault UI](https://www.vaultproject.io/docs/configuration/ui) by visiting the `vault-server` service URL in browser:
-
-```
-gcloud run services describe vault-server \
-  --platform managed \
-  --region ${TF_VAR_region} \
-  --project ${TF_VAR_project} \
-  --format 'value(status.url)'
-```
-
-You can also use the `vault` command line tool as described in the next section.
-
-### Retrieve the Vault Server Status Using the Vault Client
-
-[Download](https://www.vaultproject.io/downloads) the Vault binary and add it to your path:
-
-```
-$ vault version
-
-Vault v2.0.3
-```
-
-Configure the vault CLI to use the `vault-server` Cloud Run service URL by setting the `VAULT_ADDR` environment variable:
-
-```
-export VAULT_ADDR=$(gcloud run services describe vault-server \
-  --platform managed \
-  --region ${TF_VAR_region} \
-  --project ${TF_VAR_project} \
-  --format 'value(status.url)')
-```
-
-We also need to set the `VAULT_TOKEN`
-
-```
-gsutil cp gs://${TF_VAR_project}-key/root-token.enc . > /dev/null 2>&1
-base64 -d root-token.enc > root-token.dc
-gcloud kms decrypt --key=vault --keyring=vault-server --location=global \
-  --project=${TF_VAR_project} \
-  --ciphertext-file=root-token.dc \
-  --plaintext-file=root-token
-export VAULT_TOKEN=$(cat root-token)
-rm root-token root-token.enc root-token.dc
-```
-
-Now you can retrieve the status of the remote Vault server:
-
-```
-$ vault status
-
-Key                      Value
----                      -----
-Recovery Seal Type       shamir
-Initialized              true
-Sealed                   false
-Total Recovery Shares    1
-Threshold                1
-Version                  2.0.3
-Storage Type             gcs
-Cluster Name             vault-cluster-XXXXXXXX
-Cluster ID               XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
-HA Enabled               false
-```
+`[skip-release]` in the title so they cannot cut a Terraform module release. A
+pull request that changes both module payload and image trust must carry an
+explicit release marker. The release workflow independently suppresses
+unmarked image/trust-only changes as a second guard. Keep the `Terraform CI`
+workflow name, path, protected-main trigger, and image-contract validation
+synchronized with the Vault image workflow and shared WIF allowlist.
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
@@ -142,21 +198,21 @@ HA Enabled               false
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0, < 2.0.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22.0 |
-| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.22.0 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | ~> 7.22 |
+| <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | ~> 7.22 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 7.22.0 |
-| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 7.22.0 |
+| <a name="provider_google"></a> [google](#provider\_google) | ~> 7.22 |
+| <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | ~> 7.22 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_vault"></a> [vault](#module\_vault) | https://github.com/libops/terraform-cloudrun-v2/archive/refs/tags/0.5.2.zip//terraform-cloudrun-v2-0.5.2 | n/a |
+| <a name="module_vault"></a> [vault](#module\_vault) | https://github.com/libops/terraform-cloudrun-v2/archive/4b1c2551369ec6f31372edb33721c80daeeeab62.zip//terraform-cloudrun-v2-4b1c2551369ec6f31372edb33721c80daeeeab62 | n/a |
 
 ## Resources
 
@@ -164,38 +220,52 @@ HA Enabled               false
 |------|------|
 | [google-beta_google_cloud_run_v2_job.vault-init](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_cloud_run_v2_job) | resource |
 | [google_kms_crypto_key.key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key) | resource |
+| [google_kms_crypto_key_iam_member.initializer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_kms_crypto_key_iam_member.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
 | [google_kms_key_ring.vault-server](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_key_ring) | resource |
-| [google_service_account.gsa](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.initializer](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
+| [google_service_account.runtime](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/service_account) | resource |
 | [google_storage_bucket.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket) | resource |
+| [google_storage_bucket_iam_member.initializer_recovery](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
 | [google_storage_bucket_iam_member.member](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam_member) | resource |
-| [google_client_openid_userinfo.current](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/client_openid_userinfo) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_admin_emails"></a> [admin\_emails](#input\_admin\_emails) | List of emails (users or service accounts) that are allowed to access non-public routes by passing X-Admin-Token header with a google access token. | `list(string)` | `[]` | no |
-| <a name="input_country"></a> [country](#input\_country) | n/a | `string` | `"us"` | no |
+| <a name="input_admin_emails"></a> [admin\_emails](#input\_admin\_emails) | Explicit human or automation emails allowed to access protected Vault routes. The initializer service account is added automatically. | `list(string)` | n/a | yes |
+| <a name="input_country"></a> [country](#input\_country) | GCS location for the Vault data and recovery buckets. | `string` | `"us"` | no |
 | <a name="input_create_kms"></a> [create\_kms](#input\_create\_kms) | Whether to create the KMS key ring and crypto key. | `bool` | `true` | no |
 | <a name="input_data_bucket_name"></a> [data\_bucket\_name](#input\_data\_bucket\_name) | Bucket name for Vault data storage. Defaults to a name derived from project and service name. | `string` | `""` | no |
-| <a name="input_gsa_account_id"></a> [gsa\_account\_id](#input\_gsa\_account\_id) | Service account id for the Vault runtime. Defaults to a truncated form of name. | `string` | `""` | no |
-| <a name="input_init_image"></a> [init\_image](#input\_init\_image) | n/a | `string` | `"libops/vault-init:1.0.1"` | no |
+| <a name="input_deletion_protection"></a> [deletion\_protection](#input\_deletion\_protection) | Protect both the Vault Cloud Run service and initializer job from accidental deletion. | `bool` | `true` | no |
+| <a name="input_gsa_account_id"></a> [gsa\_account\_id](#input\_gsa\_account\_id) | Service account ID for the Vault runtime. Defaults to a truncated form of name. | `string` | `""` | no |
 | <a name="input_init_job_name"></a> [init\_job\_name](#input\_init\_job\_name) | Cloud Run job name used to initialize Vault. | `string` | `"vault-init"` | no |
-| <a name="input_key_bucket_name"></a> [key\_bucket\_name](#input\_key\_bucket\_name) | Bucket name for stored Vault init material. Defaults to a name derived from project and service name. | `string` | `""` | no |
-| <a name="input_kms_key_name"></a> [kms\_key\_name](#input\_kms\_key\_name) | KMS crypto key name used for auto-unseal. | `string` | `"vault"` | no |
+| <a name="input_initializer_execution_nonce"></a> [initializer\_execution\_nonce](#input\_initializer\_execution\_nonce) | Optional operator-controlled nonce included in the initializer execution-contract hash. Change it to deliberately request another idempotent verification. | `string` | `""` | no |
+| <a name="input_initializer_gsa_account_id"></a> [initializer\_gsa\_account\_id](#input\_initializer\_gsa\_account\_id) | Service account ID for the one-shot Vault initializer. Defaults to the service name plus -init. | `string` | `""` | no |
+| <a name="input_key_bucket_name"></a> [key\_bucket\_name](#input\_key\_bucket\_name) | Bucket name for encrypted Vault recovery material. Defaults to a name derived from project and service name. | `string` | `""` | no |
+| <a name="input_kms_key_name"></a> [kms\_key\_name](#input\_kms\_key\_name) | KMS crypto key name used for auto-unseal and recovery-material encryption. | `string` | `"vault"` | no |
 | <a name="input_kms_key_ring_name"></a> [kms\_key\_ring\_name](#input\_kms\_key\_ring\_name) | KMS key ring name used for auto-unseal. | `string` | `"vault-server"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Cloud Run service name for the Vault server. | `string` | `"vault-server"` | no |
-| <a name="input_project"></a> [project](#input\_project) | The GCP project to create or deploy the GCP resources into | `string` | n/a | yes |
-| <a name="input_public_routes"></a> [public\_routes](#input\_public\_routes) | List of Vault API paths that should be accessible without X-Admin-Token header. | `list(string)` | <pre>[<br/>  "/.well-known/",<br/>  "/v1/identity/oidc/",<br/>  "/v1/auth/oidc/",<br/>  "/v1/auth/userpass/"<br/>]</pre> | no |
-| <a name="input_region"></a> [region](#input\_region) | The region to deploy CloudRun | `string` | `"us-east5"` | no |
-| <a name="input_vault_image"></a> [vault\_image](#input\_vault\_image) | Pinned Vault server image ref used for the Vault Cloud Run container. | `string` | n/a | yes |
+| <a name="input_project"></a> [project](#input\_project) | GCP project in which to deploy Vault. | `string` | n/a | yes |
+| <a name="input_public_routes"></a> [public\_routes](#input\_public\_routes) | Optional canonical Vault Proxy v2 path patterns accessible without X-Admin-Token. /v1/sys/health is always added. | `list(string)` | <pre>[<br/>  "/.well-known/**",<br/>  "/v1/identity/oidc/provider/*/.well-known/**",<br/>  "/v1/identity/oidc/provider/*/authorize",<br/>  "/v1/identity/oidc/provider/*/token",<br/>  "/v1/identity/oidc/provider/*/userinfo",<br/>  "/ui/vault/identity/oidc/provider/*/authorize",<br/>  "/v1/auth/oidc/oidc/auth_url",<br/>  "/v1/auth/oidc/oidc/callback",<br/>  "/ui/vault/auth/*/oidc/callback",<br/>  "/v1/auth/userpass/login/**"<br/>]</pre> | no |
+| <a name="input_region"></a> [region](#input\_region) | GCP region in which to deploy the Cloud Run service and initializer job. | `string` | `"us-east5"` | no |
+| <a name="input_vault_image"></a> [vault\_image](#input\_vault\_image) | Digest-pinned GAR image reference for the Vault server container. | `string` | n/a | yes |
+| <a name="input_vault_init_image"></a> [vault\_init\_image](#input\_vault\_init\_image) | Digest-pinned GAR image reference for the Vault initializer container. | `string` | n/a | yes |
+| <a name="input_vault_proxy_image"></a> [vault\_proxy\_image](#input\_vault\_proxy\_image) | Digest-pinned GAR image reference for the Vault Proxy v2 container. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_gsa"></a> [gsa](#output\_gsa) | The GSA the Vault instance runs as. |
-| <a name="output_key_bucket"></a> [key\_bucket](#output\_key\_bucket) | n/a |
-| <a name="output_vault-url"></a> [vault-url](#output\_vault-url) | The URL to the Vault instance. |
+| <a name="output_data_bucket_name"></a> [data\_bucket\_name](#output\_data\_bucket\_name) | Bucket containing the Vault GCS storage backend. |
+| <a name="output_gsa"></a> [gsa](#output\_gsa) | Deprecated compatibility alias for runtime\_service\_account\_email. |
+| <a name="output_initializer_execution_token"></a> [initializer\_execution\_token](#output\_initializer\_execution\_token) | Deterministic 31-character run-to-completion token derived from the initializer-relevant deployment contract. |
+| <a name="output_initializer_job_name"></a> [initializer\_job\_name](#output\_initializer\_job\_name) | Name of the one-shot Vault initializer Cloud Run job. |
+| <a name="output_initializer_service_account_email"></a> [initializer\_service\_account\_email](#output\_initializer\_service\_account\_email) | Service account used by the one-shot Vault initializer job. |
+| <a name="output_key_bucket"></a> [key\_bucket](#output\_key\_bucket) | Deprecated compatibility alias for recovery\_bucket\_name. |
+| <a name="output_kms_key_id"></a> [kms\_key\_id](#output\_kms\_key\_id) | Full resource ID of the KMS key used by Vault and the initializer. |
+| <a name="output_recovery_bucket_name"></a> [recovery\_bucket\_name](#output\_recovery\_bucket\_name) | Bucket containing encrypted Vault recovery material. |
+| <a name="output_runtime_service_account_email"></a> [runtime\_service\_account\_email](#output\_runtime\_service\_account\_email) | Service account used by the long-running Vault service. |
+| <a name="output_vault-url"></a> [vault-url](#output\_vault-url) | Deprecated compatibility alias for vault\_url. |
+| <a name="output_vault_url"></a> [vault\_url](#output\_vault\_url) | URL of the Vault Cloud Run service. |
 <!-- END_TF_DOCS -->

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,115 @@
+# Upgrading to v1
+
+Version 1 intentionally changes the module's security boundary. Back up and
+verify access to the current Vault recovery material before applying an
+upgrade.
+
+## Required configuration changes
+
+1. Supply all three GAR images by digest:
+
+   ```hcl
+   vault_image       = "us-docker.pkg.dev/PROJECT/REPOSITORY/vault@sha256:DIGEST"
+   vault_proxy_image = "us-docker.pkg.dev/PROJECT/REPOSITORY/vault-proxy@sha256:DIGEST"
+   vault_init_image  = "us-docker.pkg.dev/PROJECT/REPOSITORY/vault-init@sha256:DIGEST"
+   ```
+
+   The old mutable `init_image` default and hard-coded proxy image are removed.
+
+2. Set `admin_emails` explicitly. Terraform no longer adds the credentials
+   running `terraform apply`, and the Vault runtime identity is no longer a
+   proxy administrator. The new initializer identity is added automatically.
+
+3. Replace legacy trailing-slash `public_routes` with Vault Proxy v2 canonical
+   patterns. For example, replace `/v1/auth/userpass/` with the narrower
+   `/v1/auth/userpass/login/**`.
+
+4. Ensure the selected Vault Init image is compatible with Vault Proxy v2 and
+   requests a Google metadata access token containing the `userinfo.email`
+   scope.
+
+5. Keep `init_job_name` at 30 characters or fewer. This reserves room for the
+   31-character deterministic execution suffix. A longer custom pre-v1 job
+   name must be replaced with a shorter one.
+
+## State and IAM changes
+
+The module includes this state migration:
+
+```hcl
+moved {
+  from = google_service_account.gsa
+  to   = google_service_account.runtime
+}
+```
+
+The existing service account therefore remains the Vault runtime identity. A
+new initializer service account is created. If `gsa_account_id` was set
+previously, keep the same value so Terraform preserves the existing identity.
+Use `initializer_gsa_account_id` only when the derived initializer ID conflicts
+with another account.
+
+The upgrade removes runtime access to the recovery bucket and grants the new
+initializer only Object Creator and Object Viewer there. The runtime keeps
+Object Admin on the data bucket. The runtime receives KMS Viewer plus
+Encrypt/Decrypt for Vault auto-unseal; the initializer receives only KMS
+Encrypt/Decrypt. Review the plan for those exact removals and additions before
+approval.
+
+The old `gsa`, `key_bucket`, and `vault-url` outputs remain as deprecated
+aliases. New callers should use `runtime_service_account_email`,
+`recovery_bucket_name`, and `vault_url`.
+
+## Cloud Run changes
+
+- The service is capped at one instance.
+- Service and initializer deletion protection default to enabled.
+- Vault starts first and must pass a port-specific health probe on `8200`.
+  Cloud Run then starts the dependent proxy, which must pass `/healthz` on
+  `8080`.
+- The initializer runs one task at parallelism one, retries at most three
+  times, and has a ten-minute task timeout.
+- `CHECK_INTERVAL=0s` makes the initializer one-shot.
+- The initializer run-to-completion token is a deterministic 31-character hash prefix
+  over the reviewed deployment contract. Relevant image, service, storage,
+  KMS, proxy-policy, or job-setting changes automatically request another
+  idempotent verification. Change `initializer_execution_nonce` to request one
+  explicitly without otherwise changing the deployment.
+- Direct VPC egress remains off. Version 1 does not add a VPC attachment.
+
+The v1 execution token differs from the pre-v1 value, so the first v1 apply
+runs one initializer execution after the new IAM and service revision are
+ready, and does not succeed until that execution completes. Its provider
+timeouts cover all bounded retries. Use only the hardened, idempotent Vault Init
+image for this upgrade.
+
+The initializer job is the module's only `google-beta` resource because
+`run_execution_token` remains absent from the stable provider. All other
+resources use the stable `google` provider.
+
+Cloud Run assigns the runtime service account to both co-located containers, so
+Vault Proxy inherits the runtime GCS and KMS credentials even though it does
+not use them. Review and promote the proxy and Vault images together.
+
+This remains a single-serving-instance deployment rather than an HA failover
+topology. The service-level maximum is one, and the GCS HA lock fences the brief
+revision overlap Cloud Run can still create. Vault clustering remains disabled,
+so quiesce clients and use a maintenance window for proxy, environment,
+identity, probe, sidecar, or other revision-producing changes.
+
+If the existing resources need to be destroyed, first set
+`deletion_protection = false`, apply, and then run the destroy operation.
+
+## Recommended rollout
+
+1. Verify current Vault health and a recent recovery procedure.
+2. Record the existing runtime service account, bucket names, and KMS key ID.
+3. Promote and record reviewed GAR digests for all three images.
+4. Run `terraform plan` and confirm the runtime service account is moved, not
+   replaced.
+5. Confirm the data bucket remains intact and `force_destroy` remains false.
+6. Apply in a maintenance window.
+7. Confirm `/healthz`, `/v1/sys/health`, an administrator route, and a normal
+   client authentication flow.
+8. Confirm both encrypted recovery objects are readable by the initializer
+   identity; Terraform has already required the initializer job to complete.

--- a/main.tf
+++ b/main.tf
@@ -4,142 +4,108 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 7.22.0"
+      version = "~> 7.22"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = ">= 7.22.0"
+      version = "~> 7.22"
     }
   }
 }
 
-data "google_client_openid_userinfo" "current" {}
-
 locals {
-  service_name = trimspace(var.name)
-  account_id   = trimspace(var.gsa_account_id) != "" ? trimspace(var.gsa_account_id) : substr(local.service_name, 0, 30)
-  gsa          = "${local.account_id}@${var.project}.iam.gserviceaccount.com"
+  # Keep this contract value in sync with the exact module source below so a
+  # shared service-template implementation change re-runs verification.
+  cloud_run_module_revision = "4b1c2551369ec6f31372edb33721c80daeeeab62"
+  service_name              = trimspace(var.name)
+  runtime_account_id_candidate = replace(
+    substr(local.service_name, 0, 30),
+    "/-+$/",
+    "",
+  )
+  runtime_account_id = (
+    trimspace(var.gsa_account_id) != ""
+    ? trimspace(var.gsa_account_id)
+    : (
+      length(local.runtime_account_id_candidate) >= 6
+      ? local.runtime_account_id_candidate
+      : "${substr(local.service_name, 0, 5)}0"
+    )
+  )
+  initializer_account_id = (
+    trimspace(var.initializer_gsa_account_id) != ""
+    ? trimspace(var.initializer_gsa_account_id)
+    : "${substr(local.service_name, 0, 25)}-init"
+  )
+  runtime_service_account_email     = google_service_account.runtime.email
+  initializer_service_account_email = google_service_account.initializer.email
   data_bucket_name = trimspace(var.data_bucket_name) != "" ? trimspace(var.data_bucket_name) : lower(
     replace(replace(replace("${var.project}-${local.service_name}-data", "_", "-"), ".", "-"), " ", "-")
   )
-  key_bucket_name = trimspace(var.key_bucket_name) != "" ? trimspace(var.key_bucket_name) : lower(
+  recovery_bucket_name = trimspace(var.key_bucket_name) != "" ? trimspace(var.key_bucket_name) : lower(
     replace(replace(replace("${var.project}-${local.service_name}-key", "_", "-"), ".", "-"), " ", "-")
   )
 
-  # see https://github.com/libops/vault-proxy/blob/main/config.example.yaml
-  vault_proxy_config = {
-    vault_addr = "http://127.0.0.1:8200"
-    port       = 8080
-    admin_emails = concat(
-      var.admin_emails,
-      [
-        data.google_client_openid_userinfo.current.email,
-        local.gsa,
-      ]
-    )
-    public_routes = concat(
-      var.public_routes,
-      ["/v1/sys/health"] # Essential for health checks
-    )
-  }
-  vault_proxy_yaml = yamlencode(local.vault_proxy_config)
-}
-
-## Create the GSA the Vault CloudRun deployment will run as
-resource "google_service_account" "gsa" {
-  project    = var.project
-  account_id = local.account_id
-}
-
-## Create buckets to store the Vault backend (data) and root token (key)
-resource "google_storage_bucket" "vault" {
-  for_each = {
-    data = local.data_bucket_name
-    key  = local.key_bucket_name
-  }
-  project                     = var.project
-  name                        = each.value
-  location                    = var.country
-  force_destroy               = false
-  uniform_bucket_level_access = true
-  public_access_prevention    = "enforced"
-}
-
-resource "google_storage_bucket_iam_member" "member" {
-  for_each = toset([
-    google_storage_bucket.vault["data"].name,
-    google_storage_bucket.vault["key"].name
-  ])
-  bucket = each.value
-  role   = "roles/storage.objectAdmin"
-  member = format("serviceAccount:%s", google_service_account.gsa.email)
-}
-
-## Create KMS keys
-resource "google_kms_key_ring" "vault-server" {
-  count    = var.create_kms ? 1 : 0
-  project  = var.project
-  name     = var.kms_key_ring_name
-  location = "global"
-}
-
-resource "google_kms_crypto_key" "key" {
-  count    = var.create_kms ? 1 : 0
-  name     = var.kms_key_name
-  key_ring = google_kms_key_ring.vault-server[0].id
-
-  lifecycle {
-    prevent_destroy = true
-  }
-}
-
-locals {
   kms_key_id = var.create_kms ? google_kms_crypto_key.key[0].id : format(
     "projects/%s/locations/global/keyRings/%s/cryptoKeys/%s",
     var.project,
     var.kms_key_ring_name,
     var.kms_key_name,
   )
-}
 
-resource "google_kms_crypto_key_iam_member" "vault" {
-  for_each = toset([
-    "roles/cloudkms.viewer",
-    "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  ])
+  # Vault Proxy v2 accepts only canonical explicit route patterns. The
+  # initializer identity is the only workload identity that bypasses the
+  # public-route allowlist; the Vault runtime identity is intentionally absent.
+  vault_proxy_config = {
+    vault_addr = "http://127.0.0.1:8200"
+    port       = 8080
+    admin_emails = distinct([
+      for email in concat(var.admin_emails, [local.initializer_service_account_email]) :
+      lower(email)
+    ])
+    public_routes = distinct(concat(var.public_routes, ["/v1/sys/health"]))
+  }
+  vault_proxy_yaml = yamlencode(local.vault_proxy_config)
 
-  crypto_key_id = local.kms_key_id
-  role          = each.value
-  member        = format("serviceAccount:%s", google_service_account.gsa.email)
-}
-
-module "vault" {
-  source = "https://github.com/libops/terraform-cloudrun-v2/archive/refs/tags/0.5.2.zip//terraform-cloudrun-v2-0.5.2"
-
-  name          = local.service_name
-  project       = var.project
-  regions       = [var.region]
-  skipNeg       = true
-  gsa           = google_service_account.gsa.email
-  min_instances = 0
-  max_instances = 1
-  containers = tolist([
+  proxy_startup_probe = {
+    path                  = "/healthz"
+    port                  = 8080
+    initial_delay_seconds = 0
+    timeout_seconds       = 2
+    period_seconds        = 5
+    failure_threshold     = 24
+  }
+  vault_startup_probe = {
+    path                  = "/v1/sys/health?uninitcode=200"
+    port                  = 8200
+    initial_delay_seconds = 0
+    timeout_seconds       = 2
+    period_seconds        = 5
+    failure_threshold     = 48
+  }
+  vault_containers = [
     {
-      name   = "proxy",
-      image  = "libops/vault-proxy:1.0.1@sha256:515910b8208d82376b8973c6ae26d14ce6f56f8935547f69057dd82d2fa50c2f"
-      port   = 8080
-      memory = "512Mi"
-      cpu    = "500m"
+      name                 = "vault"
+      image                = var.vault_image
+      depends_on           = []
+      port                 = 0
+      memory               = "2Gi"
+      cpu                  = "2000m"
+      liveness_probe       = ""
+      startup_probe_config = local.vault_startup_probe
     },
     {
-      name   = "vault",
-      image  = var.vault_image
-      memory = "2Gi"
-      cpu    = "2000m"
-    }
-  ])
-
-  addl_env_vars = tolist([
+      name                 = "proxy"
+      image                = var.vault_proxy_image
+      depends_on           = ["vault"]
+      port                 = 8080
+      memory               = "512Mi"
+      cpu                  = "500m"
+      liveness_probe       = "/healthz"
+      startup_probe_config = local.proxy_startup_probe
+    },
+  ]
+  vault_environment = tolist([
     {
       name  = "GOOGLE_PROJECT"
       value = var.project
@@ -159,57 +125,244 @@ module "vault" {
     {
       name  = "VAULT_PROXY_YAML"
       value = local.vault_proxy_yaml
+    },
+  ])
+  initializer_environment = {
+    CHECK_INTERVAL         = "0s"
+    GCS_BUCKET_NAME        = google_storage_bucket.vault["key"].name
+    GOOGLE_PROJECT         = var.project
+    KMS_KEY_ID             = local.kms_key_id
+    VAULT_ADDR             = module.vault.urls[var.region]
+    VAULT_SECRET_SHARES    = "0"
+    VAULT_SECRET_THRESHOLD = "0"
+  }
+  initializer_job_settings = {
+    task_count      = 1
+    parallelism     = 1
+    max_retries     = 3
+    timeout         = "600s"
+    execution_nonce = var.initializer_execution_nonce
+  }
+  initializer_execution_contract = {
+    images = {
+      vault       = var.vault_image
+      vault_init  = var.vault_init_image
+      vault_proxy = var.vault_proxy_image
     }
+    service = {
+      name                              = local.service_name
+      project                           = var.project
+      region                            = var.region
+      runtime_service_account_email     = local.runtime_service_account_email
+      initializer_service_account_email = local.initializer_service_account_email
+      data_bucket_name                  = local.data_bucket_name
+      recovery_bucket_name              = local.recovery_bucket_name
+      kms_key_id = format(
+        "projects/%s/locations/global/keyRings/%s/cryptoKeys/%s",
+        var.project,
+        var.kms_key_ring_name,
+        var.kms_key_name,
+      )
+      max_instances             = "1"
+      deletion_protection       = var.deletion_protection
+      direct_vpc_egress         = "OFF"
+      containers                = local.vault_containers
+      cloud_run_module_revision = local.cloud_run_module_revision
+    }
+    proxy = local.vault_proxy_config
+    initializer = {
+      job_name                 = var.init_job_name
+      service_account_email    = local.initializer_service_account_email
+      environment              = local.initializer_environment
+      task_count               = local.initializer_job_settings.task_count
+      parallelism              = local.initializer_job_settings.parallelism
+      max_retries              = local.initializer_job_settings.max_retries
+      timeout                  = local.initializer_job_settings.timeout
+      operator_execution_nonce = local.initializer_job_settings.execution_nonce
+    }
+  }
+  initializer_run_execution_token = substr(
+    sha256(jsonencode(local.initializer_execution_contract)),
+    0,
+    31,
+  )
+
+  # This module deliberately does not attach Vault to a VPC. Callers that need
+  # private egress should compose that concern outside this security boundary.
+  vault_vpc_direct_egress = "OFF"
+  vault_min_instances     = "0"
+  vault_max_instances     = "1"
+}
+
+# Preserve the existing runtime identity and its state address during the v1
+# split. The initializer receives a new, separately privileged identity.
+moved {
+  from = google_service_account.gsa
+  to   = google_service_account.runtime
+}
+
+resource "google_service_account" "runtime" {
+  project      = var.project
+  account_id   = local.runtime_account_id
+  display_name = "Vault runtime"
+}
+
+resource "google_service_account" "initializer" {
+  project      = var.project
+  account_id   = local.initializer_account_id
+  display_name = "Vault initializer"
+
+  lifecycle {
+    precondition {
+      condition     = local.runtime_account_id != local.initializer_account_id
+      error_message = "The Vault runtime and initializer must use distinct service account IDs."
+    }
+    precondition {
+      condition = !contains(
+        [for email in var.admin_emails : lower(email)],
+        lower(local.runtime_service_account_email),
+      )
+      error_message = "The Vault runtime service account must not be listed as a proxy administrator."
+    }
+  }
+}
+
+resource "google_storage_bucket" "vault" {
+  for_each = {
+    data = local.data_bucket_name
+    key  = local.recovery_bucket_name
+  }
+
+  project                     = var.project
+  name                        = each.value
+  location                    = var.country
+  force_destroy               = false
+  uniform_bucket_level_access = true
+  public_access_prevention    = "enforced"
+}
+
+# The long-running Vault server can modify only its data backend.
+resource "google_storage_bucket_iam_member" "member" {
+  for_each = toset([google_storage_bucket.vault["data"].name])
+
+  bucket = each.value
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+# The one-shot initializer can create and read recovery objects but cannot
+# delete or overwrite them.
+resource "google_storage_bucket_iam_member" "initializer_recovery" {
+  for_each = toset([
+    "roles/storage.objectCreator",
+    "roles/storage.objectViewer",
   ])
 
-  depends_on = [google_kms_crypto_key_iam_member.vault]
+  bucket = google_storage_bucket.vault["key"].name
+  role   = each.value
+  member = "serviceAccount:${google_service_account.initializer.email}"
+}
+
+resource "google_kms_key_ring" "vault-server" {
+  count    = var.create_kms ? 1 : 0
+  project  = var.project
+  name     = var.kms_key_ring_name
+  location = "global"
+}
+
+resource "google_kms_crypto_key" "key" {
+  count    = var.create_kms ? 1 : 0
+  name     = var.kms_key_name
+  key_ring = google_kms_key_ring.vault-server[0].id
+
+  lifecycle {
+    prevent_destroy = true
+  }
+}
+
+resource "google_kms_crypto_key_iam_member" "vault" {
+  for_each = toset([
+    "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+    "roles/cloudkms.viewer",
+  ])
+
+  crypto_key_id = local.kms_key_id
+  role          = each.value
+  member        = "serviceAccount:${google_service_account.runtime.email}"
+}
+
+resource "google_kms_crypto_key_iam_member" "initializer" {
+  crypto_key_id = local.kms_key_id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.initializer.email}"
+}
+
+module "vault" {
+  source = "https://github.com/libops/terraform-cloudrun-v2/archive/4b1c2551369ec6f31372edb33721c80daeeeab62.zip//terraform-cloudrun-v2-4b1c2551369ec6f31372edb33721c80daeeeab62"
+
+  name                = local.service_name
+  project             = var.project
+  regions             = [var.region]
+  skipNeg             = true
+  gsa                 = google_service_account.runtime.email
+  min_instances       = local.vault_min_instances
+  max_instances       = local.vault_max_instances
+  deletion_protection = var.deletion_protection
+  invokers            = ["allUsers"]
+  containers          = local.vault_containers
+  addl_env_vars       = local.vault_environment
+  vpc_direct_egress   = local.vault_vpc_direct_egress
+
+  depends_on = [
+    google_kms_crypto_key_iam_member.vault,
+    google_storage_bucket_iam_member.member,
+  ]
 }
 
 resource "google_cloud_run_v2_job" "vault-init" {
   provider = google-beta
 
-  name                  = var.init_job_name
-  project               = var.project
-  location              = var.region
-  deletion_protection   = false
-  start_execution_token = "start-once-created"
+  name                = var.init_job_name
+  project             = var.project
+  location            = var.region
+  deletion_protection = var.deletion_protection
+  run_execution_token = local.initializer_run_execution_token
+
+  # run_execution_token blocks until the execution succeeds. Four possible
+  # ten-minute attempts plus scheduling overhead must fit inside provider CRUD
+  # timeouts so a failed initializer makes terraform apply fail.
+  timeouts {
+    create = "60m"
+    update = "60m"
+  }
+
   template {
+    task_count  = local.initializer_job_settings.task_count
+    parallelism = local.initializer_job_settings.parallelism
+
     template {
-      service_account = google_service_account.gsa.email
+      service_account = google_service_account.initializer.email
+      max_retries     = local.initializer_job_settings.max_retries
+      timeout         = local.initializer_job_settings.timeout
+
       containers {
         name  = "vault-init"
-        image = var.init_image
+        image = var.vault_init_image
 
-        env {
-          name  = "GOOGLE_PROJECT"
-          value = var.project
-        }
-        env {
-          name  = "GCS_BUCKET_NAME"
-          value = google_storage_bucket.vault["key"].name
-        }
-        env {
-          name  = "CHECK_INTERVAL"
-          value = "-1"
-        }
-        env {
-          name  = "KMS_KEY_ID"
-          value = local.kms_key_id
-        }
-        env {
-          name  = "VAULT_ADDR"
-          value = module.vault.urls[var.region]
-        }
-        env {
-          name  = "VAULT_SECRET_SHARES"
-          value = 0
-        }
-        env {
-          name  = "VAULT_SECRET_THRESHOLD"
-          value = 0
+        dynamic "env" {
+          for_each = local.initializer_environment
+          content {
+            name  = env.key
+            value = env.value
+          }
         }
       }
     }
   }
-  depends_on = [module.vault]
+
+  depends_on = [
+    module.vault,
+    google_kms_crypto_key_iam_member.initializer,
+    google_storage_bucket_iam_member.initializer_recovery,
+  ]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,13 +1,56 @@
+output "vault_url" {
+  value       = module.vault.urls[var.region]
+  description = "URL of the Vault Cloud Run service."
+}
+
+output "runtime_service_account_email" {
+  value       = google_service_account.runtime.email
+  description = "Service account used by the long-running Vault service."
+}
+
+output "initializer_service_account_email" {
+  value       = google_service_account.initializer.email
+  description = "Service account used by the one-shot Vault initializer job."
+}
+
+output "data_bucket_name" {
+  value       = google_storage_bucket.vault["data"].name
+  description = "Bucket containing the Vault GCS storage backend."
+}
+
+output "recovery_bucket_name" {
+  value       = google_storage_bucket.vault["key"].name
+  description = "Bucket containing encrypted Vault recovery material."
+}
+
+output "kms_key_id" {
+  value       = local.kms_key_id
+  description = "Full resource ID of the KMS key used by Vault and the initializer."
+}
+
+output "initializer_job_name" {
+  value       = google_cloud_run_v2_job.vault-init.name
+  description = "Name of the one-shot Vault initializer Cloud Run job."
+}
+
+output "initializer_execution_token" {
+  value       = local.initializer_run_execution_token
+  description = "Deterministic 31-character run-to-completion token derived from the initializer-relevant deployment contract."
+}
+
+# Compatibility aliases retained for existing callers. Prefer the descriptive
+# underscore-separated outputs above in new configurations.
 output "vault-url" {
   value       = module.vault.urls[var.region]
-  description = "The URL to the Vault instance."
+  description = "Deprecated compatibility alias for vault_url."
 }
 
 output "gsa" {
-  value       = google_service_account.gsa.email
-  description = "The GSA the Vault instance runs as."
+  value       = google_service_account.runtime.email
+  description = "Deprecated compatibility alias for runtime_service_account_email."
 }
 
 output "key_bucket" {
-  value = local.key_bucket_name
+  value       = google_storage_bucket.vault["key"].name
+  description = "Deprecated compatibility alias for recovery_bucket_name."
 }

--- a/tests/vault.tftest.hcl
+++ b/tests/vault.tftest.hcl
@@ -1,0 +1,410 @@
+mock_provider "google" {
+  override_during = plan
+
+  mock_data "google_service_account" {
+    defaults = {
+      email = "vault-server@example-project.iam.gserviceaccount.com"
+    }
+  }
+}
+
+mock_provider "google-beta" {
+  override_during = plan
+}
+
+override_resource {
+  target          = google_service_account.runtime
+  override_during = plan
+  values = {
+    email = "vault-server@example-project.iam.gserviceaccount.com"
+  }
+}
+
+override_resource {
+  target          = google_service_account.initializer
+  override_during = plan
+  values = {
+    email = "vault-server-init@example-project.iam.gserviceaccount.com"
+  }
+}
+
+override_resource {
+  target          = google_kms_crypto_key.key[0]
+  override_during = plan
+  values = {
+    id = "projects/example-project/locations/global/keyRings/vault-server/cryptoKeys/vault"
+  }
+}
+
+override_module {
+  target = module.vault
+  outputs = {
+    urls = {
+      "us-central1" = "https://vault-server.example.test"
+    }
+  }
+}
+
+variables {
+  project           = "example-project"
+  region            = "us-central1"
+  admin_emails      = ["vault-admin@example.org"]
+  vault_image       = "us-docker.pkg.dev/example-project/public/vault@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  vault_proxy_image = "us-docker.pkg.dev/example-project/public/vault-proxy@sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  vault_init_image  = "us-docker.pkg.dev/example-project/public/vault-init@sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"
+}
+
+run "splits_runtime_and_initializer_privileges" {
+  command = plan
+
+  assert {
+    condition = (
+      google_service_account.runtime.account_id != google_service_account.initializer.account_id &&
+      length(google_storage_bucket_iam_member.member) == 1 &&
+      alltrue([
+        for binding in google_storage_bucket_iam_member.member :
+        binding.bucket == google_storage_bucket.vault["data"].name &&
+        binding.role == "roles/storage.objectAdmin" &&
+        binding.member == "serviceAccount:${google_service_account.runtime.email}"
+      ])
+    )
+    error_message = "The runtime identity must be distinct and limited to objectAdmin on the data bucket."
+  }
+
+  assert {
+    condition = alltrue([
+      for binding in google_storage_bucket_iam_member.initializer_recovery :
+      binding.bucket == google_storage_bucket.vault["key"].name &&
+      binding.member == "serviceAccount:${google_service_account.initializer.email}"
+    ])
+    error_message = "The initializer recovery bindings must target only the recovery bucket and initializer identity."
+  }
+
+  assert {
+    condition = toset([
+      for binding in google_storage_bucket_iam_member.initializer_recovery :
+      binding.role
+      ]) == toset([
+      "roles/storage.objectCreator",
+      "roles/storage.objectViewer",
+    ])
+    error_message = "The initializer must be able to create and view recovery objects without objectAdmin."
+  }
+
+  assert {
+    condition = (
+      toset([
+        for binding in google_kms_crypto_key_iam_member.vault :
+        binding.role
+        ]) == toset([
+        "roles/cloudkms.cryptoKeyEncrypterDecrypter",
+        "roles/cloudkms.viewer",
+      ]) &&
+      alltrue([
+        for binding in google_kms_crypto_key_iam_member.vault :
+        binding.member == "serviceAccount:${google_service_account.runtime.email}"
+      ]) &&
+      google_kms_crypto_key_iam_member.initializer.role == "roles/cloudkms.cryptoKeyEncrypterDecrypter" &&
+      google_kms_crypto_key_iam_member.initializer.member == "serviceAccount:${google_service_account.initializer.email}"
+    )
+    error_message = "Vault runtime must receive KMS get plus encrypt/decrypt, while the initializer receives only encrypt/decrypt."
+  }
+}
+
+run "configures_vault_proxy_v2_boundary" {
+  command = plan
+
+  assert {
+    condition = (
+      length(local.vault_proxy_config.admin_emails) == 2 &&
+      contains(local.vault_proxy_config.admin_emails, "vault-admin@example.org") &&
+      contains(local.vault_proxy_config.admin_emails, local.initializer_service_account_email) &&
+      !contains(local.vault_proxy_config.admin_emails, local.runtime_service_account_email)
+    )
+    error_message = "Only explicit administrators and the initializer may access protected proxy routes."
+  }
+
+  assert {
+    condition = (
+      contains(local.vault_proxy_config.public_routes, "/v1/auth/userpass/login/**") &&
+      contains(local.vault_proxy_config.public_routes, "/v1/sys/health") &&
+      alltrue([
+        for route in local.vault_proxy_config.public_routes :
+        !endswith(route, "/")
+      ])
+    )
+    error_message = "Proxy routes must use canonical v2 patterns rather than legacy prefixes."
+  }
+
+  assert {
+    condition = (
+      local.vault_containers[0].name == "vault" &&
+      local.vault_containers[0].image == var.vault_image &&
+      local.vault_containers[0].startup_probe_config.port == 8200 &&
+      local.vault_containers[0].startup_probe_config.path == "/v1/sys/health?uninitcode=200" &&
+      local.vault_containers[0].startup_probe_config.failure_threshold *
+      local.vault_containers[0].startup_probe_config.period_seconds == 240 &&
+      local.vault_containers[1].name == "proxy" &&
+      local.vault_containers[1].image == var.vault_proxy_image &&
+      local.vault_containers[1].depends_on == ["vault"] &&
+      local.vault_containers[1].startup_probe_config.path == "/healthz" &&
+      local.vault_containers[1].startup_probe_config.port == 8080 &&
+      local.vault_containers[1].liveness_probe == "/healthz" &&
+      local.vault_vpc_direct_egress == "OFF" &&
+      local.vault_max_instances == "1" &&
+      local.initializer_execution_contract.service.cloud_run_module_revision == "4b1c2551369ec6f31372edb33721c80daeeeab62" &&
+      var.deletion_protection
+    )
+    error_message = "Vault must become reachable on port 8200 before the pinned proxy starts, and Direct VPC must remain off."
+  }
+}
+
+run "configures_bounded_one_shot_initializer" {
+  command = plan
+
+  assert {
+    condition = (
+      google_cloud_run_v2_job.vault-init.deletion_protection &&
+      google_cloud_run_v2_job.vault-init.run_execution_token == local.initializer_run_execution_token &&
+      google_cloud_run_v2_job.vault-init.start_execution_token == null &&
+      length(local.initializer_run_execution_token) == 31 &&
+      local.initializer_run_execution_token == substr(sha256(jsonencode(local.initializer_execution_contract)), 0, 31) &&
+      google_cloud_run_v2_job.vault-init.template[0].task_count == 1 &&
+      google_cloud_run_v2_job.vault-init.template[0].parallelism == 1 &&
+      google_cloud_run_v2_job.vault-init.template[0].template[0].max_retries == 3 &&
+      google_cloud_run_v2_job.vault-init.template[0].template[0].timeout == "600s" &&
+      google_cloud_run_v2_job.vault-init.template[0].template[0].service_account == google_service_account.initializer.email
+    )
+    error_message = "The initializer must be deletion-protected, serialized, retry-bounded, and use its isolated identity."
+  }
+
+  assert {
+    condition = (
+      google_cloud_run_v2_job.vault-init.template[0].template[0].containers[0].image == var.vault_init_image &&
+      local.initializer_environment.CHECK_INTERVAL == "0s"
+    )
+    error_message = "The initializer must use its pinned image and one-shot check interval."
+  }
+}
+
+run "changed_initializer_image_changes_execution_token" {
+  command = plan
+
+  variables {
+    vault_init_image = "us-docker.pkg.dev/example-project/public/vault-init@sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"
+  }
+
+  assert {
+    condition     = output.initializer_execution_token != run.configures_bounded_one_shot_initializer.initializer_execution_token
+    error_message = "Changing the initializer image digest must change the deterministic execution token."
+  }
+}
+
+run "operator_nonce_changes_execution_token" {
+  command = plan
+
+  variables {
+    initializer_execution_nonce = "verify-after-incident-1"
+  }
+
+  assert {
+    condition     = output.initializer_execution_token != run.configures_bounded_one_shot_initializer.initializer_execution_token
+    error_message = "Changing the operator nonce must change the deterministic execution token."
+  }
+}
+
+run "preserves_compatibility_outputs" {
+  command = plan
+
+  assert {
+    condition = (
+      output.vault-url == output.vault_url &&
+      output.gsa == output.runtime_service_account_email &&
+      output.key_bucket == output.recovery_bucket_name
+    )
+    error_message = "Legacy output aliases must resolve to the new descriptive outputs."
+  }
+}
+
+run "rejects_empty_admin_allowlist" {
+  command = plan
+
+  variables {
+    admin_emails = []
+  }
+
+  expect_failures = [var.admin_emails]
+}
+
+run "rejects_legacy_proxy_route_prefixes" {
+  command = plan
+
+  variables {
+    public_routes = ["/v1/auth/userpass/"]
+  }
+
+  expect_failures = [var.public_routes]
+}
+
+run "always_exposes_required_vault_health" {
+  command = plan
+
+  variables {
+    public_routes = []
+  }
+
+  assert {
+    condition = (
+      length(local.vault_proxy_config.public_routes) == 1 &&
+      contains(local.vault_proxy_config.public_routes, "/v1/sys/health")
+    )
+    error_message = "Vault health must remain public even when optional public routes are empty."
+  }
+}
+
+run "rejects_nonfinal_recursive_wildcard" {
+  command = plan
+
+  variables {
+    public_routes = ["/v1/**/config/**"]
+  }
+
+  expect_failures = [var.public_routes]
+}
+
+run "rejects_non_gar_vault_image" {
+  command = plan
+
+  variables {
+    vault_image = "ghcr.io/libops/vault@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+
+  expect_failures = [var.vault_image]
+}
+
+run "rejects_whitespace_around_image" {
+  command = plan
+
+  variables {
+    vault_image = " us-docker.pkg.dev/example-project/public/vault@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+
+  expect_failures = [var.vault_image]
+}
+
+run "rejects_unpinned_proxy_image" {
+  command = plan
+
+  variables {
+    vault_proxy_image = "us-docker.pkg.dev/example-project/public/vault-proxy:2.0.0"
+  }
+
+  expect_failures = [var.vault_proxy_image]
+}
+
+run "rejects_unpinned_initializer_image" {
+  command = plan
+
+  variables {
+    vault_init_image = "us-docker.pkg.dev/example-project/public/vault-init:1.0.2"
+  }
+
+  expect_failures = [var.vault_init_image]
+}
+
+run "rejects_shared_service_account_id" {
+  command = plan
+
+  variables {
+    gsa_account_id             = "shared-vault"
+    initializer_gsa_account_id = "shared-vault"
+  }
+
+  expect_failures = [google_service_account.initializer]
+}
+
+run "rejects_runtime_identity_as_explicit_admin" {
+  command = plan
+
+  variables {
+    admin_emails = ["vault-server@example-project.iam.gserviceaccount.com"]
+  }
+
+  expect_failures = [google_service_account.initializer]
+}
+
+run "rejects_mixed_case_runtime_identity_as_explicit_admin" {
+  command = plan
+
+  variables {
+    admin_emails = ["VAULT-SERVER@EXAMPLE-PROJECT.IAM.GSERVICEACCOUNT.COM"]
+  }
+
+  expect_failures = [google_service_account.initializer]
+}
+
+run "rejects_case_insensitive_duplicate_admins" {
+  command = plan
+
+  variables {
+    admin_emails = [
+      "vault-admin@example.org",
+      "VAULT-ADMIN@EXAMPLE.ORG",
+    ]
+  }
+
+  expect_failures = [var.admin_emails]
+}
+
+run "rejects_invalid_kms_key_ring_name" {
+  command = plan
+
+  variables {
+    kms_key_ring_name = "invalid/ring"
+  }
+
+  expect_failures = [var.kms_key_ring_name]
+}
+
+run "rejects_oversized_kms_key_name" {
+  command = plan
+
+  variables {
+    kms_key_name = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  }
+
+  expect_failures = [var.kms_key_name]
+}
+
+run "derives_valid_runtime_identity_from_hyphenated_name" {
+  command = plan
+
+  variables {
+    name = "a------------------------------b"
+  }
+
+  assert {
+    condition     = google_service_account.runtime.account_id == "a----0"
+    error_message = "The derived runtime service account ID must remain valid after trimming a long trailing hyphen run."
+  }
+}
+
+run "rejects_whitespace_around_initializer_nonce" {
+  command = plan
+
+  variables {
+    initializer_execution_nonce = " rerun"
+  }
+
+  expect_failures = [var.initializer_execution_nonce]
+}
+
+run "rejects_initializer_job_name_over_thirty_characters" {
+  command = plan
+
+  variables {
+    init_job_name = "vault-initializer-job-name-is-too-long"
+  }
+
+  expect_failures = [var.init_job_name]
+}

--- a/variables.tf
+++ b/variables.tf
@@ -1,50 +1,153 @@
 variable "project" {
   type        = string
-  description = "The GCP project to create or deploy the GCP resources into"
+  description = "GCP project in which to deploy Vault."
+
+  validation {
+    condition     = trimspace(var.project) != "" && trimspace(var.project) == var.project
+    error_message = "project must not be empty or contain leading or trailing whitespace."
+  }
 }
 
 variable "region" {
   type        = string
-  description = "The region to deploy CloudRun"
+  description = "GCP region in which to deploy the Cloud Run service and initializer job."
   default     = "us-east5"
+
+  validation {
+    condition     = can(regex("^[a-z]+(?:-[a-z0-9]+)+[0-9]$", var.region))
+    error_message = "region must be a valid GCP region name."
+  }
 }
 
 variable "name" {
   type        = string
   description = "Cloud Run service name for the Vault server."
   default     = "vault-server"
+
+  validation {
+    condition = (
+      length(var.name) >= 6 &&
+      length(var.name) <= 49 &&
+      can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.name))
+    )
+    error_message = "name must be a 6-49 character lowercase Cloud Run service name."
+  }
 }
 
 variable "gsa_account_id" {
   type        = string
-  description = "Service account id for the Vault runtime. Defaults to a truncated form of name."
+  description = "Service account ID for the Vault runtime. Defaults to a truncated form of name."
   default     = ""
+
+  validation {
+    condition = (
+      trimspace(var.gsa_account_id) == "" ||
+      can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", trimspace(var.gsa_account_id)))
+    )
+    error_message = "gsa_account_id must be empty or a valid 6-30 character GCP service account ID."
+  }
+}
+
+variable "initializer_gsa_account_id" {
+  type        = string
+  description = "Service account ID for the one-shot Vault initializer. Defaults to the service name plus -init."
+  default     = ""
+
+  validation {
+    condition = (
+      trimspace(var.initializer_gsa_account_id) == "" ||
+      can(regex("^[a-z][a-z0-9-]{4,28}[a-z0-9]$", trimspace(var.initializer_gsa_account_id)))
+    )
+    error_message = "initializer_gsa_account_id must be empty or a valid 6-30 character GCP service account ID."
+  }
 }
 
 variable "init_job_name" {
   type        = string
   description = "Cloud Run job name used to initialize Vault."
   default     = "vault-init"
+
+  validation {
+    condition = (
+      length(var.init_job_name) >= 1 &&
+      length(var.init_job_name) <= 30 &&
+      can(regex("^[a-z]([a-z0-9-]*[a-z0-9])?$", var.init_job_name))
+    )
+    error_message = "init_job_name must be a valid 1-30 character lowercase Cloud Run job name so its execution suffix remains within Cloud Run's limit."
+  }
+}
+
+variable "initializer_execution_nonce" {
+  type        = string
+  description = "Optional operator-controlled nonce included in the initializer execution-contract hash. Change it to deliberately request another idempotent verification."
+  default     = ""
+
+  validation {
+    condition = (
+      length(var.initializer_execution_nonce) <= 128 &&
+      trimspace(var.initializer_execution_nonce) == var.initializer_execution_nonce
+    )
+    error_message = "initializer_execution_nonce must be at most 128 characters with no leading or trailing whitespace."
+  }
 }
 
 variable "vault_image" {
   type        = string
-  description = "Pinned Vault server image ref used for the Vault Cloud Run container."
+  description = "Digest-pinned GAR image reference for the Vault server container."
 
   validation {
-    condition     = var.vault_image != "" && can(regex("@sha256:[0-9a-f]{64}$", var.vault_image))
-    error_message = "vault_image must be set and pinned to a sha256 digest."
+    condition = (
+      trimspace(var.vault_image) == var.vault_image &&
+      can(regex(
+        "^[a-z0-9-]+-docker\\.pkg\\.dev/[^/@[:space:]]+/[^/@[:space:]]+/[^@[:space:]]+@sha256:[0-9a-f]{64}$",
+        var.vault_image,
+      ))
+    )
+    error_message = "vault_image must be a GAR reference pinned to a sha256 digest."
   }
 }
 
-variable "init_image" {
-  type    = string
-  default = "libops/vault-init:1.0.1"
+variable "vault_proxy_image" {
+  type        = string
+  description = "Digest-pinned GAR image reference for the Vault Proxy v2 container."
+
+  validation {
+    condition = (
+      trimspace(var.vault_proxy_image) == var.vault_proxy_image &&
+      can(regex(
+        "^[a-z0-9-]+-docker\\.pkg\\.dev/[^/@[:space:]]+/[^/@[:space:]]+/[^@[:space:]]+@sha256:[0-9a-f]{64}$",
+        var.vault_proxy_image,
+      ))
+    )
+    error_message = "vault_proxy_image must be a GAR reference pinned to a sha256 digest."
+  }
+}
+
+variable "vault_init_image" {
+  type        = string
+  description = "Digest-pinned GAR image reference for the Vault initializer container."
+
+  validation {
+    condition = (
+      trimspace(var.vault_init_image) == var.vault_init_image &&
+      can(regex(
+        "^[a-z0-9-]+-docker\\.pkg\\.dev/[^/@[:space:]]+/[^/@[:space:]]+/[^@[:space:]]+@sha256:[0-9a-f]{64}$",
+        var.vault_init_image,
+      ))
+    )
+    error_message = "vault_init_image must be a GAR reference pinned to a sha256 digest."
+  }
 }
 
 variable "country" {
-  type    = string
-  default = "us"
+  type        = string
+  description = "GCS location for the Vault data and recovery buckets."
+  default     = "us"
+
+  validation {
+    condition     = trimspace(var.country) != "" && trimspace(var.country) == var.country
+    error_message = "country must not be empty or contain leading or trailing whitespace."
+  }
 }
 
 variable "data_bucket_name" {
@@ -55,7 +158,7 @@ variable "data_bucket_name" {
 
 variable "key_bucket_name" {
   type        = string
-  description = "Bucket name for stored Vault init material. Defaults to a name derived from project and service name."
+  description = "Bucket name for encrypted Vault recovery material. Defaults to a name derived from project and service name."
   default     = ""
 }
 
@@ -63,12 +166,22 @@ variable "kms_key_ring_name" {
   type        = string
   description = "KMS key ring name used for auto-unseal."
   default     = "vault-server"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_-]{1,63}$", var.kms_key_ring_name))
+    error_message = "kms_key_ring_name must contain 1-63 ASCII letters, digits, underscores, or hyphens."
+  }
 }
 
 variable "kms_key_name" {
   type        = string
-  description = "KMS crypto key name used for auto-unseal."
+  description = "KMS crypto key name used for auto-unseal and recovery-material encryption."
   default     = "vault"
+
+  validation {
+    condition     = can(regex("^[A-Za-z0-9_-]{1,63}$", var.kms_key_name))
+    error_message = "kms_key_name must contain 1-63 ASCII letters, digits, underscores, or hyphens."
+  }
 }
 
 variable "create_kms" {
@@ -77,19 +190,84 @@ variable "create_kms" {
   default     = true
 }
 
+variable "deletion_protection" {
+  type        = bool
+  description = "Protect both the Vault Cloud Run service and initializer job from accidental deletion."
+  default     = true
+}
+
 variable "admin_emails" {
-  description = "List of emails (users or service accounts) that are allowed to access non-public routes by passing X-Admin-Token header with a google access token."
   type        = list(string)
-  default     = []
+  description = "Explicit human or automation emails allowed to access protected Vault routes. The initializer service account is added automatically."
+
+  validation {
+    condition = (
+      length(var.admin_emails) > 0 &&
+      length(distinct([for email in var.admin_emails : lower(email)])) == length(var.admin_emails) &&
+      alltrue([
+        for email in var.admin_emails :
+        trimspace(email) == email &&
+        can(regex("^[^@[:space:]]+@[^@[:space:]]+$", email))
+      ])
+    )
+    error_message = "admin_emails must contain at least one case-insensitively unique, valid email address."
+  }
 }
 
 variable "public_routes" {
-  description = "List of Vault API paths that should be accessible without X-Admin-Token header."
   type        = list(string)
+  description = "Optional canonical Vault Proxy v2 path patterns accessible without X-Admin-Token. /v1/sys/health is always added."
   default = [
-    "/.well-known/",
-    "/v1/identity/oidc/",
-    "/v1/auth/oidc/",
-    "/v1/auth/userpass/",
+    "/.well-known/**",
+    "/v1/identity/oidc/provider/*/.well-known/**",
+    "/v1/identity/oidc/provider/*/authorize",
+    "/v1/identity/oidc/provider/*/token",
+    "/v1/identity/oidc/provider/*/userinfo",
+    "/ui/vault/identity/oidc/provider/*/authorize",
+    "/v1/auth/oidc/oidc/auth_url",
+    "/v1/auth/oidc/oidc/callback",
+    "/ui/vault/auth/*/oidc/callback",
+    "/v1/auth/userpass/login/**",
   ]
+
+  validation {
+    condition = (
+      length(distinct(var.public_routes)) == length(var.public_routes) &&
+      alltrue([
+        for route in var.public_routes : (
+          trimspace(route) == route &&
+          startswith(route, "/") &&
+          !endswith(route, "/") &&
+          !strcontains(route, "//") &&
+          route != "/**" &&
+          !strcontains(route, "?") &&
+          !strcontains(route, "[") &&
+          !strcontains(route, "]") &&
+          !strcontains(route, "\\") &&
+          !strcontains(route, "/./") &&
+          !strcontains(route, "/../") &&
+          !endswith(route, "/.") &&
+          !endswith(route, "/..") &&
+          length([
+            for segment in split("/", trimprefix(route, "/")) :
+            segment if segment == "**"
+          ]) <= 1 &&
+          alltrue([
+            for segment in split("/", trimprefix(route, "/")) :
+            segment != "" &&
+            (
+              segment == "*" ||
+              segment == "**" ||
+              !strcontains(segment, "*")
+            )
+          ]) &&
+          (
+            !strcontains(route, "**") ||
+            endswith(route, "/**")
+          )
+        )
+      ])
+    )
+    error_message = "public_routes must contain unique canonical Vault Proxy v2 absolute path patterns; legacy trailing-slash prefixes are invalid."
+  }
 }


### PR DESCRIPTION
Defines the downstream-consumable v1 Vault deployment contract.

- separates runtime and initializer identities and bucket/KMS permissions
- requires all Vault, Proxy v2, and Init images as digest-pinned GAR inputs
- uses canonical Proxy v2 routes and exact Cloud Run 0.8.0 startup ordering
- runs one bounded, idempotent initializer task from a deterministic deployment-contract token
- keeps Direct VPC off because this service has no private VPC dependency
- documents the co-located proxy credential inheritance and mandatory offline handling of every non-HA service revision
- replaces false-green CI/release automation with Terraform tests, TFLint, docs/action linting, and the shared release workflow

Keep this PR unmerged until Vault Proxy 2.0.0, Vault Init 1.0.2, and the Vault server image are verified in GAR by digest.