### PR TITLE
[skip-release] Publish Vault 2.0.3 image

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -1,17 +1,106 @@
-name: lint
+name: Terraform CI
+
 on:
+  pull_request:
   push:
+    branches:
+      - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: terraform-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  run:
-    permissions:
-      contents: read
+  validate:
+    name: Terraform
     runs-on: ubuntu-24.04
+    timeout-minutes: 20
+
     steps:
-    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
 
-    - uses: hashicorp/setup-terraform@5e8dbf3c6d9deaf4193ca7a8fb23f2ac83bb6c85 # v4
-      with:
-        terraform_version: 1.5.7
+      - name: Set up Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4
+        with:
+          terraform_version: 1.15.2
 
-    - name: lint
-      run: terraform fmt **/*.tf
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.5"
+
+      - name: Install terraform-docs
+        run: go install github.com/terraform-docs/terraform-docs@v0.20.0
+
+      - name: Check formatting
+        run: terraform fmt -check -recursive .
+
+      - name: Check generated documentation
+        run: terraform-docs markdown table --lockfile=false --output-check --output-file README.md .
+
+      - name: Initialize
+        run: terraform init -backend=false -input=false
+
+      - name: Validate
+        run: terraform validate
+
+      - name: Test
+        run: terraform test
+
+      - name: Set up TFLint
+        uses: terraform-linters/setup-tflint@b480b8fcdaa6f2c577f8e4fa799e89e756bb7c93 # v6
+        with:
+          tflint_version: v0.63.1
+
+      - name: Lint Terraform
+        run: |
+          tflint --init
+          tflint --recursive
+
+  workflows:
+    name: GitHub Actions
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
+        with:
+          go-version: "1.26.5"
+
+      - name: Validate workflows
+        run: go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12
+
+      - name: Validate Vault image contract
+        run: bash scripts/check-vault-image-contract.sh
+
+  required:
+    name: CI / required
+    if: ${{ always() }}
+    needs:
+      - validate
+      - workflows
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+
+    steps:
+      - name: Require all validation jobs
+        env:
+          TERRAFORM_RESULT: ${{ needs.validate.result }}
+          WORKFLOWS_RESULT: ${{ needs.workflows.result }}
+        run: |
+          set -euo pipefail
+          test "$TERRAFORM_RESULT" = success
+          test "$WORKFLOWS_RESULT" = success

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,30 +1,55 @@
 name: Create release
+
 on:
   pull_request_target:
     branches:
       - main
     types:
       - closed
+
 permissions:
-  contents: write
-  actions: write
+  contents: read
+  pull-requests: read
+
 jobs:
-  release:
-    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.title, '[skip-release]')
+  classify:
+    name: Classify merged change
+    if: github.event.pull_request.merged == true
     runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    outputs:
+      release-module: ${{ steps.change.outputs.release-module }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
-
-      - name: install autotag binary
-        run: curl -sL https://git.io/autotag-install | sudo sh -s -- -b /usr/bin
-
-      - name: create release
-        run: |-
-          TAG=$(autotag)
-          git push origin $TAG
-          gh release create $TAG --title "$TAG" --generate-notes
+      - name: Keep image changes out of module releases
+        id: change
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          release_module=true
+          if [[ "$PR_TITLE" == *"[skip-release]"* ]]; then
+            release_module=false
+          fi
+          changed_files="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[] | .filename, (.previous_filename // empty)'
+          )"
+          while IFS= read -r changed_file; do
+            case "$changed_file" in
+              Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/lint-test.yml|.github/workflows/vault-image.yml)
+                release_module=false
+                ;;
+            esac
+          done <<< "$changed_files"
+          echo "release-module=$release_module" >> "$GITHUB_OUTPUT"
+
+  release:
+    needs: classify
+    if: needs.classify.outputs.release-module == 'true'
+    uses: libops/.github/.github/workflows/bump-release.yaml@e1e30b58c9c566f72b22f03e637cd5218d635727
+    permissions:
+      contents: write
+      actions: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,19 +31,32 @@ jobs:
           release_module=true
           if [[ "$PR_TITLE" == *"[skip-release]"* ]]; then
             release_module=false
+          elif [[ "$PR_TITLE" != *"[major]"* &&
+                  "$PR_TITLE" != *"[minor]"* &&
+                  "$PR_TITLE" != *"[patch]"* ]]; then
+            image_or_trust_changed=false
+            other_changed=false
+            changed_files="$(
+              gh api --paginate \
+                "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+                --jq '.[] | .filename, (.previous_filename // empty)'
+            )"
+            while IFS= read -r changed_file; do
+              case "$changed_file" in
+                Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/lint-test.yml|.github/workflows/release.yml|.github/workflows/vault-image.yml)
+                  image_or_trust_changed=true
+                  ;;
+                README.md)
+                  ;;
+                *)
+                  other_changed=true
+                  ;;
+              esac
+            done <<< "$changed_files"
+            if [[ "$image_or_trust_changed" == true && "$other_changed" == false ]]; then
+              release_module=false
+            fi
           fi
-          changed_files="$(
-            gh api --paginate \
-              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
-              --jq '.[] | .filename, (.previous_filename // empty)'
-          )"
-          while IFS= read -r changed_file; do
-            case "$changed_file" in
-              Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/lint-test.yml|.github/workflows/vault-image.yml)
-                release_module=false
-                ;;
-            esac
-          done <<< "$changed_files"
           echo "release-module=$release_module" >> "$GITHUB_OUTPUT"
 
   release:

--- a/.github/workflows/vault-image.yml
+++ b/.github/workflows/vault-image.yml
@@ -13,6 +13,7 @@ on:
       - vault-server.hcl.tmpl
       - scripts/check-vault-image-contract.sh
       - .github/workflows/lint-test.yml
+      - .github/workflows/release.yml
       - .github/workflows/vault-image.yml
   workflow_run:
     workflows:
@@ -35,6 +36,9 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-24.04
     timeout-minutes: 5
+    permissions:
+      contents: read
+      pull-requests: read
     steps:
       - name: Check out repository
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -46,13 +50,47 @@ jobs:
 
       - name: Require image and module release separation
         env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
         run: |
           set -euo pipefail
-          [[ "$PR_TITLE" == *"[skip-release]"* ]] || {
-            echo "Vault image changes require [skip-release] so they cannot release the Terraform module" >&2
-            exit 1
-          }
+          image_payload_changed=false
+          image_trust_changed=false
+          module_payload_changed=false
+          changed_files="$(
+            gh api --paginate \
+              "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" \
+              --jq '.[] | .filename, (.previous_filename // empty)'
+          )"
+          while IFS= read -r changed_file; do
+            case "$changed_file" in
+              Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/vault-image.yml)
+                image_payload_changed=true
+                ;;
+              .github/workflows/lint-test.yml|.github/workflows/release.yml)
+                image_trust_changed=true
+                ;;
+              *.tf|.terraform.lock.hcl|Makefile|UPGRADING.md|examples/*|modules/*|tests/*)
+                module_payload_changed=true
+                ;;
+            esac
+          done <<< "$changed_files"
+          if [[ "$image_payload_changed" == true ||
+                "$image_trust_changed" == true && "$module_payload_changed" == false ]]; then
+            [[ "$PR_TITLE" == *"[skip-release]"* ]] || {
+              echo "Vault image changes require [skip-release] so they cannot release the Terraform module" >&2
+              exit 1
+            }
+          elif [[ "$image_trust_changed" == true ]]; then
+            [[ "$PR_TITLE" == *"[major]"* ||
+               "$PR_TITLE" == *"[minor]"* ||
+               "$PR_TITLE" == *"[patch]"* ||
+               "$PR_TITLE" == *"[skip-release]"* ]] || {
+              echo "Mixed image-trust and module changes require an explicit release marker" >&2
+              exit 1
+            }
+          fi
 
   build:
     name: Build and scan / ${{ matrix.architecture.platform }}

--- a/.github/workflows/vault-image.yml
+++ b/.github/workflows/vault-image.yml
@@ -214,7 +214,7 @@ jobs:
     name: Publish Vault / GHCR and GAR
     if: needs.authorize.outputs.eligible == 'true'
     needs: authorize
-    uses: libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    uses: libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     with:
       image: vault-server
       ref: ${{ github.event.workflow_run.head_sha }}
@@ -223,7 +223,7 @@ jobs:
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
     secrets:
       GCLOUD_OIDC_POOL: ${{ secrets.GCLOUD_OIDC_POOL }}
       GSA: ${{ secrets.GSA }}

--- a/.github/workflows/vault-image.yml
+++ b/.github/workflows/vault-image.yml
@@ -252,7 +252,7 @@ jobs:
     name: Publish Vault / GHCR and GAR
     if: needs.authorize.outputs.eligible == 'true'
     needs: authorize
-    uses: libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     with:
       image: vault-server
       ref: ${{ github.event.workflow_run.head_sha }}
@@ -261,7 +261,7 @@ jobs:
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     secrets:
       GCLOUD_OIDC_POOL: ${{ secrets.GCLOUD_OIDC_POOL }}
       GSA: ${{ secrets.GSA }}

--- a/.github/workflows/vault-image.yml
+++ b/.github/workflows/vault-image.yml
@@ -1,0 +1,277 @@
+name: Vault image
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - edited
+    paths:
+      - Dockerfile
+      - docker-entrypoint.sh
+      - vault-server.hcl.tmpl
+      - scripts/check-vault-image-contract.sh
+      - .github/workflows/lint-test.yml
+      - .github/workflows/vault-image.yml
+  workflow_run:
+    workflows:
+      - Terraform CI
+    types:
+      - completed
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: vault-image-${{ github.event_name == 'pull_request' && github.event.pull_request.number || 'main' }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  contract:
+    name: Image contract
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Validate image publication contract
+        run: bash scripts/check-vault-image-contract.sh
+
+      - name: Require image and module release separation
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          set -euo pipefail
+          [[ "$PR_TITLE" == *"[skip-release]"* ]] || {
+            echo "Vault image changes require [skip-release] so they cannot release the Terraform module" >&2
+            exit 1
+          }
+
+  build:
+    name: Build and scan / ${{ matrix.architecture.platform }}
+    if: github.event_name == 'pull_request'
+    needs: contract
+    runs-on: ${{ matrix.architecture.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        architecture:
+          - runner: ubuntu-24.04
+            platform: linux/amd64
+            suffix: amd64
+          - runner: ubuntu-24.04-arm
+            platform: linux/arm64
+            suffix: arm64
+    env:
+      LOCAL_IMAGE: libops-ci/vault-server:${{ github.sha }}-${{ matrix.architecture.suffix }}
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3
+
+      - name: Build native image without publisher credentials
+        uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
+        with:
+          context: .
+          file: Dockerfile
+          load: true
+          platforms: ${{ matrix.architecture.platform }}
+          provenance: false
+          push: false
+          tags: ${{ env.LOCAL_IMAGE }}
+
+      - name: Verify Vault version and runtime identity
+        shell: bash
+        run: |
+          set -euo pipefail
+          image_tag="$(bash scripts/check-vault-image-contract.sh --print-tag)"
+          vault_version="${image_tag%%-libops.*}"
+          docker run --rm --entrypoint /usr/local/bin/vault "$LOCAL_IMAGE" version |
+            grep -F "Vault v${vault_version}"
+          test "$(docker run --rm --entrypoint /bin/sh "$LOCAL_IMAGE" -c 'id -u')" = 65532
+          docker run --rm \
+            -e KMS_KEY_RING='ring-one' \
+            -e KMS_CRYPTO_KEY='key_two' \
+            "$LOCAL_IMAGE" \
+            /bin/sh -ec '
+              test -r /tmp/vault-config.hcl
+              grep -F "key_ring   = \"ring-one\"" /tmp/vault-config.hcl
+              grep -F "crypto_key = \"key_two\"" /tmp/vault-config.hcl
+              test "$(stat -c %a /tmp/vault-config.hcl)" = 600
+            '
+          if docker run --rm \
+            -e KMS_KEY_RING='ring&one' \
+            -e KMS_CRYPTO_KEY='key-two' \
+            "$LOCAL_IMAGE" true; then
+            echo "Malformed KMS resource name unexpectedly reached Vault" >&2
+            exit 1
+          fi
+          if docker run --rm \
+            -e KMS_KEY_RING='aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' \
+            -e KMS_CRYPTO_KEY='key-two' \
+            "$LOCAL_IMAGE" true; then
+            echo "Oversized KMS resource name unexpectedly reached Vault" >&2
+            exit 1
+          fi
+
+      - name: Scan native image
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ env.LOCAL_IMAGE }}
+          format: table
+          exit-code: "1"
+          ignore-unfixed: true
+          severity: HIGH,CRITICAL
+          vuln-type: os,library
+
+  authorize:
+    name: Classify and authorize post-CI image commit
+    if: github.event_name == 'workflow_run'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      eligible: ${{ steps.eligibility.outputs.eligible }}
+      image-tag: ${{ steps.image.outputs.tag }}
+    env:
+      PUBLISH_SHA: ${{ github.event.workflow_run.head_sha }}
+    steps:
+      - name: Classify triggering workflow
+        id: eligibility
+        env:
+          CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          CI_EVENT: ${{ github.event.workflow_run.event }}
+          CI_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          CI_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          CI_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+        run: |
+          set -euo pipefail
+          eligible=false
+          if [[ "$CI_CONCLUSION" == success &&
+                "$CI_EVENT" == push &&
+                "$CI_HEAD_BRANCH" == main &&
+                "$CI_HEAD_REPOSITORY" == "$GITHUB_REPOSITORY" &&
+                "$CI_WORKFLOW_PATH" == .github/workflows/lint-test.yml ]]; then
+            eligible=true
+          fi
+          echo "eligible=$eligible" >> "$GITHUB_OUTPUT"
+
+      - name: Check out exact CI commit
+        if: steps.eligibility.outputs.eligible == 'true'
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
+          fetch-depth: 2
+          persist-credentials: false
+
+      - name: Require successful CI for the current main commit
+        if: steps.eligibility.outputs.eligible == 'true'
+        env:
+          CI_CONCLUSION: ${{ github.event.workflow_run.conclusion }}
+          CI_EVENT: ${{ github.event.workflow_run.event }}
+          CI_HEAD_BRANCH: ${{ github.event.workflow_run.head_branch }}
+          CI_HEAD_REPOSITORY: ${{ github.event.workflow_run.head_repository.full_name }}
+          CI_WORKFLOW_PATH: ${{ github.event.workflow_run.path }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          test "$CI_CONCLUSION" = success
+          test "$CI_EVENT" = push
+          test "$CI_HEAD_BRANCH" = main
+          test "$CI_HEAD_REPOSITORY" = "$GITHUB_REPOSITORY"
+          test "$CI_WORKFLOW_PATH" = .github/workflows/lint-test.yml
+          [[ "$PUBLISH_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$PUBLISH_SHA"
+          current_main="$(gh api "repos/${GITHUB_REPOSITORY}/git/ref/heads/main" --jq '.object.sha')"
+          test "$current_main" = "$PUBLISH_SHA"
+
+      - name: Resolve immutable image metadata
+        id: image
+        if: steps.eligibility.outputs.eligible == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          bash scripts/check-vault-image-contract.sh
+          base_tag="$(bash scripts/check-vault-image-contract.sh --print-tag)"
+          image_tag="${base_tag}-sha-${PUBLISH_SHA}-run-${GITHUB_RUN_ID}-attempt-${GITHUB_RUN_ATTEMPT}"
+          [[ "${#image_tag}" -le 128 ]]
+          echo "tag=$image_tag" >> "$GITHUB_OUTPUT"
+
+  publish:
+    name: Publish Vault / GHCR and GAR
+    if: needs.authorize.outputs.eligible == 'true'
+    needs: authorize
+    uses: libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    with:
+      image: vault-server
+      ref: ${{ github.event.workflow_run.head_sha }}
+      tag: ${{ needs.authorize.outputs.image-tag }}
+      expected-main-sha: ${{ github.event.workflow_run.head_sha }}
+      additional-gar-registry: us-docker.pkg.dev/libops-images/public
+      scan: true
+      sign: true
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@578137212ead4ab4059e95df17fa30e9b7ac4aed
+    secrets:
+      GCLOUD_OIDC_POOL: ${{ secrets.GCLOUD_OIDC_POOL }}
+      GSA: ${{ secrets.GSA }}
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+  required:
+    name: Vault image / required
+    if: always()
+    needs:
+      - contract
+      - build
+      - authorize
+      - publish
+    runs-on: ubuntu-24.04
+    timeout-minutes: 5
+    steps:
+      - name: Require event-specific image jobs
+        env:
+          AUTHORIZE_RESULT: ${{ needs.authorize.result }}
+          BUILD_RESULT: ${{ needs.build.result }}
+          CONTRACT_RESULT: ${{ needs.contract.result }}
+          ELIGIBLE_WORKFLOW_RUN: ${{ needs.authorize.outputs.eligible }}
+          EVENT_NAME: ${{ github.event_name }}
+          PUBLISH_RESULT: ${{ needs.publish.result }}
+        run: |
+          set -euo pipefail
+          case "$EVENT_NAME" in
+            pull_request)
+              test "$CONTRACT_RESULT" = success
+              test "$BUILD_RESULT" = success
+              test "$AUTHORIZE_RESULT" = skipped
+              test "$PUBLISH_RESULT" = skipped
+              ;;
+            workflow_run)
+              test "$CONTRACT_RESULT" = skipped
+              test "$BUILD_RESULT" = skipped
+              test "$AUTHORIZE_RESULT" = success
+              if [[ "$ELIGIBLE_WORKFLOW_RUN" == true ]]; then
+                test "$PUBLISH_RESULT" = success
+              else
+                test "$PUBLISH_RESULT" = skipped
+              fi
+              ;;
+            *)
+              printf 'Unsupported event: %s\n' "$EVENT_NAME" >&2
+              exit 1
+              ;;
+          esac

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,47 @@
-FROM debian:trixie-20260406@sha256:3352c2e13876c8a5c5873ef20870e1939e73cb9a3c1aeba5e3e72172a85ce9ed as builder
-ARG DEBIAN_FRONTEND=noninteractive
-# renovate: datasource=github-releases depName=hashicorp-vault-cli packageName=hashicorp/vault
-ARG VAULT_VERSION=1.21.4
-RUN apt-get update && apt-get install -y wget unzip
-RUN wget -q https://releases.hashicorp.com/vault/${VAULT_VERSION}/vault_${VAULT_VERSION}_linux_amd64.zip
-RUN unzip vault_${VAULT_VERSION}_linux_amd64.zip
+FROM golang:1.26.5-bookworm@sha256:1ecb7edf62a0408027bd5729dfd6b1b8766e578e8df93995b225dfd0944eb651 AS builder
 
-FROM alpine:3.23@sha256:5b10f432ef3da1b8d4c7eb6c487f2f5a8f096bc91145e68878dd4a5019afde11
-RUN apk --update add ca-certificates
-RUN mkdir -p /etc/vault
-COPY --from=builder /vault .
-COPY vault-server.hcl.tmpl /etc/vault/config.hcl.tmpl
-COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+ARG TARGETARCH
+ARG VAULT_VERSION=2.0.3
+ARG VAULT_COMMIT=7193f9a48ff6093ca61b3b627a8671e770428ba6
+
+WORKDIR /src
+RUN set -eux; \
+    git init; \
+    git remote add origin https://github.com/hashicorp/vault.git; \
+    git fetch --depth=1 origin "${VAULT_COMMIT}"; \
+    git checkout --detach FETCH_HEAD; \
+    test "$(git rev-parse HEAD)" = "${VAULT_COMMIT}"; \
+    test "$(cat version/VERSION)" = "${VAULT_VERSION}"
+
+RUN set -eux; \
+    case "${TARGETARCH}" in amd64|arm64) ;; *) exit 1 ;; esac; \
+    GOFLAGS=-buildvcs=false CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" BUILD_TAGS=ui ./scripts/build.sh; \
+    install -D -m 0555 bin/vault /out/vault; \
+    /out/vault version | grep -F "Vault v${VAULT_VERSION}"
+
+FROM alpine:3.23@sha256:fd791d74b68913cbb027c6546007b3f0d3bc45125f797758156952bc2d6daf40
+
+ARG VAULT_VERSION=2.0.3
+ARG IMAGE_REVISION=1
+
+LABEL org.opencontainers.image.title="LibOps Vault server" \
+      org.opencontainers.image.description="Vault ${VAULT_VERSION} for the LibOps Cloud Run module" \
+      org.opencontainers.image.source="https://github.com/libops/terraform-vault-cloudrun" \
+      org.opencontainers.image.licenses="BUSL-1.1" \
+      org.opencontainers.image.version="${VAULT_VERSION}-libops.${IMAGE_REVISION}"
+
+RUN apk add --no-cache 'ca-certificates=20260611-r0' && \
+    mkdir -p /etc/vault && \
+    chown 0:0 /etc/vault && \
+    chmod 0755 /etc/vault
+
+COPY --from=builder --chown=0:0 --chmod=0555 /out/vault /usr/local/bin/vault
+COPY --from=builder --chown=0:0 --chmod=0444 /src/LICENSE /licenses/Vault-LICENSE
+COPY --chown=0:0 --chmod=0444 vault-server.hcl.tmpl /etc/vault/config.hcl.tmpl
+COPY --chown=0:0 --chmod=0555 docker-entrypoint.sh /docker-entrypoint.sh
+
+USER 65532:65532
+
+EXPOSE 8200
+
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -31,6 +31,13 @@ preserving the reviewed Vault source identity. The runtime uses a numeric
 non-root identity and renders its seal config at startup from the
 `KMS_KEY_RING` and `KMS_CRYPTO_KEY` environment variables.
 
+The GCS backend enables its HA lock as a fencing boundary. The Cloud Run module
+normally caps the service at one instance, but Cloud Run can briefly overlap
+revisions or exceed a configured maximum. The lock prevents two Vault servers
+from becoming active against the same backend. Clustering remains disabled
+because Cloud Run services cannot address an individual instance's cluster
+listener; this is storage safety, not a highly available serving topology.
+
 Image publication is intentionally separate from module releases and ordinary
 API image bundles. A change to the Dockerfile, entrypoint, config template, or
 image workflow is built and scanned without credentials in pull requests. Once

--- a/README.md
+++ b/README.md
@@ -22,9 +22,38 @@ After this module has been ran, the Vault server is up and running and has been 
 Pass a pinned `vault_image` digest to deploy the Vault server container. The
 module no longer builds or pushes Docker images during Terraform runs, so it
 can run from Cloud Run jobs and other environments without Docker daemon access.
-The included Dockerfile still builds a universal Vault image that renders its
-seal config at container startup from the runtime `KMS_KEY_RING` and
-`KMS_CRYPTO_KEY` environment variables.
+The included Dockerfile builds the independently released, multi-platform
+`vault-server` image. It checks out the exact upstream Vault 2.0.3 commit and
+rebuilds the official UI-enabled target with a digest-pinned patched Go
+toolchain before copying only the binary and license into the runtime. This
+avoids inheriting vulnerabilities from an older upstream compiler while
+preserving the reviewed Vault source identity. The runtime uses a numeric
+non-root identity and renders its seal config at startup from the
+`KMS_KEY_RING` and `KMS_CRYPTO_KEY` environment variables.
+
+Image publication is intentionally separate from module releases and ordinary
+API image bundles. A change to the Dockerfile, entrypoint, config template, or
+image workflow is built and scanned without credentials in pull requests. Once
+the exact commit passes the protected main CI workflow, the shared LibOps image
+publisher signs the same multi-platform manifest in GHCR and
+`us-docker.pkg.dev/libops-images/public`. Image tags include the upstream Vault
+version, the LibOps packaging revision, the exact source commit, and the
+publication run. Every publication therefore receives a unique tag;
+deployments must still use the verified digest.
+
+Pull requests that change the image or its CI trust anchor must retain
+`[skip-release]` in the title, including after title edits, so an image-only
+change cannot cut a Terraform module release. The release workflow also
+classifies the merged PR file list and refuses a module release whenever image
+or image-trust files changed, so the title marker is not the sole enforcement
+boundary. Completed CI runs that are not a successful push from this
+repository's current `main` branch are treated as intentional publication
+no-ops.
+
+The `Terraform CI` workflow at `.github/workflows/lint-test.yml` is part of the
+publisher identity and event trust boundary. Keep its name, path, protected-main
+push trigger, and image-contract validation synchronized with the image
+workflow and shared WIF configuration.
 
 If you list the GCS storage bucket you will see a new set of directories created by Vault:
 
@@ -55,7 +84,7 @@ You can also use the `vault` command line tool as described in the next section.
 ```
 $ vault version
 
-Vault v1.12.3 (209b3dd99fe8ca320340d08c70cff5f620261f9b), built 2023-02-02T09:07:27Z
+Vault v2.0.3
 ```
 
 Configure the vault CLI to use the `vault-server` Cloud Run service URL by setting the `VAULT_ADDR` environment variable:
@@ -93,8 +122,7 @@ Initialized              true
 Sealed                   false
 Total Recovery Shares    1
 Threshold                1
-Version                  1.12.3
-Build Date               2023-02-02T09:07:27Z
+Version                  2.0.3
 Storage Type             gcs
 Cluster Name             vault-cluster-XXXXXXXX
 Cluster ID               XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX
@@ -105,27 +133,28 @@ HA Enabled               false
 ## Requirements
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.7.0, < 2.0.0 |
 | <a name="requirement_google"></a> [google](#requirement\_google) | >= 7.22.0 |
 | <a name="requirement_google-beta"></a> [google-beta](#requirement\_google-beta) | >= 7.22.0 |
 
 ## Providers
 
 | Name | Version |
-| ---- | ------- |
+|------|---------|
 | <a name="provider_google"></a> [google](#provider\_google) | >= 7.22.0 |
 | <a name="provider_google-beta"></a> [google-beta](#provider\_google-beta) | >= 7.22.0 |
 
 ## Modules
 
 | Name | Source | Version |
-| ---- | ------ | ------- |
+|------|--------|---------|
 | <a name="module_vault"></a> [vault](#module\_vault) | https://github.com/libops/terraform-cloudrun-v2/archive/refs/tags/0.5.2.zip//terraform-cloudrun-v2-0.5.2 | n/a |
 
 ## Resources
 
 | Name | Type |
-| ---- | ---- |
+|------|------|
 | [google-beta_google_cloud_run_v2_job.vault-init](https://registry.terraform.io/providers/hashicorp/google-beta/latest/docs/resources/google_cloud_run_v2_job) | resource |
 | [google_kms_crypto_key.key](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key) | resource |
 | [google_kms_crypto_key_iam_member.vault](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/kms_crypto_key_iam_member) | resource |
@@ -138,9 +167,7 @@ HA Enabled               false
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-| ---- | ----------- | ---- | ------- | :------: |
-| <a name="input_project"></a> [project](#input\_project) | The GCP project to create or deploy the GCP resources into | `string` | n/a | yes |
-| <a name="input_vault_image"></a> [vault\_image](#input\_vault\_image) | Pinned Vault server image ref used for the Vault Cloud Run container. | `string` | n/a | yes |
+|------|-------------|------|---------|:--------:|
 | <a name="input_admin_emails"></a> [admin\_emails](#input\_admin\_emails) | List of emails (users or service accounts) that are allowed to access non-public routes by passing X-Admin-Token header with a google access token. | `list(string)` | `[]` | no |
 | <a name="input_country"></a> [country](#input\_country) | n/a | `string` | `"us"` | no |
 | <a name="input_create_kms"></a> [create\_kms](#input\_create\_kms) | Whether to create the KMS key ring and crypto key. | `bool` | `true` | no |
@@ -152,13 +179,15 @@ HA Enabled               false
 | <a name="input_kms_key_name"></a> [kms\_key\_name](#input\_kms\_key\_name) | KMS crypto key name used for auto-unseal. | `string` | `"vault"` | no |
 | <a name="input_kms_key_ring_name"></a> [kms\_key\_ring\_name](#input\_kms\_key\_ring\_name) | KMS key ring name used for auto-unseal. | `string` | `"vault-server"` | no |
 | <a name="input_name"></a> [name](#input\_name) | Cloud Run service name for the Vault server. | `string` | `"vault-server"` | no |
+| <a name="input_project"></a> [project](#input\_project) | The GCP project to create or deploy the GCP resources into | `string` | n/a | yes |
 | <a name="input_public_routes"></a> [public\_routes](#input\_public\_routes) | List of Vault API paths that should be accessible without X-Admin-Token header. | `list(string)` | <pre>[<br/>  "/.well-known/",<br/>  "/v1/identity/oidc/",<br/>  "/v1/auth/oidc/",<br/>  "/v1/auth/userpass/"<br/>]</pre> | no |
 | <a name="input_region"></a> [region](#input\_region) | The region to deploy CloudRun | `string` | `"us-east5"` | no |
+| <a name="input_vault_image"></a> [vault\_image](#input\_vault\_image) | Pinned Vault server image ref used for the Vault Cloud Run container. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
-| ---- | ----------- |
+|------|-------------|
 | <a name="output_gsa"></a> [gsa](#output\_gsa) | The GSA the Vault instance runs as. |
 | <a name="output_key_bucket"></a> [key\_bucket](#output\_key\_bucket) | n/a |
 | <a name="output_vault-url"></a> [vault-url](#output\_vault-url) | The URL to the Vault instance. |

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ version, the LibOps packaging revision, the exact source commit, and the
 publication run. Every publication therefore receives a unique tag;
 deployments must still use the verified digest.
 
-Pull requests that change the image or its CI trust anchor must retain
-`[skip-release]` in the title, including after title edits, so an image-only
-change cannot cut a Terraform module release. The release workflow also
-classifies the merged PR file list and refuses a module release whenever image
-or image-trust files changed, so the title marker is not the sole enforcement
-boundary. Completed CI runs that are not a successful push from this
-repository's current `main` branch are treated as intentional publication
-no-ops.
+Image payload pull requests and image-trust-only pull requests must retain
+`[skip-release]` in the title, including after title edits, so they cannot cut a
+Terraform module release. A pull request that changes both module payload and
+image trust must carry an explicit release marker. The release workflow also
+classifies the merged PR file list and suppresses unmarked image/trust-only
+changes, so the title marker is not the sole enforcement boundary. Completed CI
+runs that are not a successful push from this repository's current `main`
+branch are treated as intentional publication no-ops.
 
 The `Terraform CI` workflow at `.github/workflows/lint-test.yml` is part of the
 publisher identity and event trust boundary. Keep its name, path, protected-main

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -5,6 +5,29 @@ set -eu
 : "${KMS_KEY_RING:?KMS_KEY_RING is required}"
 : "${KMS_CRYPTO_KEY:?KMS_CRYPTO_KEY is required}"
 
+case "$KMS_KEY_RING" in
+  *[!A-Za-z0-9_-]*)
+    printf 'KMS_KEY_RING must be a Google Cloud KMS resource name\n' >&2
+    exit 1
+    ;;
+esac
+if [ "${#KMS_KEY_RING}" -gt 63 ]; then
+  printf 'KMS_KEY_RING must be at most 63 characters\n' >&2
+  exit 1
+fi
+case "$KMS_CRYPTO_KEY" in
+  *[!A-Za-z0-9_-]*)
+    printf 'KMS_CRYPTO_KEY must be a Google Cloud KMS resource name\n' >&2
+    exit 1
+    ;;
+esac
+if [ "${#KMS_CRYPTO_KEY}" -gt 63 ]; then
+  printf 'KMS_CRYPTO_KEY must be at most 63 characters\n' >&2
+  exit 1
+fi
+
+umask 077
+
 escape_sed_replacement() {
   printf '%s' "$1" | sed 's/[&|]/\\&/g'
 }
@@ -16,4 +39,8 @@ sed \
   -e "s|__KMS_CRYPTO_KEY__|$(escape_sed_replacement "$KMS_CRYPTO_KEY")|g" \
   /etc/vault/config.hcl.tmpl > "$config_path"
 
-exec /vault server -config "$config_path"
+if [ "$#" -gt 0 ]; then
+  exec "$@"
+fi
+
+exec /usr/local/bin/vault server -config "$config_path"

--- a/main.tf
+++ b/main.tf
@@ -1,4 +1,6 @@
 terraform {
+  required_version = ">= 1.7.0, < 2.0.0"
+
   required_providers {
     google = {
       source  = "hashicorp/google"

--- a/scripts/check-vault-image-contract.sh
+++ b/scripts/check-vault-image-contract.sh
@@ -86,8 +86,20 @@ grep -Fq '      - edited' "$workflow" ||
   fail "editing an image pull request title does not rerun release separation"
 grep -Fq '      - .github/workflows/lint-test.yml' "$workflow" ||
   fail "changes to the image CI trust anchor do not run the image checks"
+grep -Fq '      - .github/workflows/release.yml' "$workflow" ||
+  fail "changes to the release-separation trust anchor do not run the image checks"
 grep -Fq '[[ "$PR_TITLE" == *"[skip-release]"* ]]' "$workflow" ||
   fail "image changes can release the Terraform module"
+grep -Fq 'image_payload_changed=false' "$workflow" ||
+  fail "image and module changes are not classified separately"
+grep -Fq 'image_trust_changed=false' "$workflow" ||
+  fail "image trust changes are not classified separately"
+grep -Fq 'module_payload_changed=false' "$workflow" ||
+  fail "module payload changes are not classified separately"
+grep -Fq 'if [[ "$image_payload_changed" == true ||' "$workflow" ||
+  fail "image release separation is not limited to image payload changes"
+grep -Fq 'Mixed image-trust and module changes require an explicit release marker' "$workflow" ||
+  fail "mixed trust and module changes do not require explicit release intent"
 for eligibility_condition in \
   '"$CI_CONCLUSION" == success' \
   '"$CI_EVENT" == push' \
@@ -156,7 +168,10 @@ for release_contract in \
   'changed_files="$(' \
   'gh api --paginate \' \
   '.previous_filename // empty' \
-  'Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/lint-test.yml|.github/workflows/vault-image.yml)' \
+  'elif [[ "$PR_TITLE" != *"[major]"* &&' \
+  'image_or_trust_changed=false' \
+  'Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/lint-test.yml|.github/workflows/release.yml|.github/workflows/vault-image.yml)' \
+  'if [[ "$image_or_trust_changed" == true && "$other_changed" == false ]]; then' \
   'if: needs.classify.outputs.release-module == '\''true'\'''; do
   grep -Fq "$release_contract" "$release_workflow" ||
     fail "the module release workflow no longer classifies image-only changes: $release_contract"

--- a/scripts/check-vault-image-contract.sh
+++ b/scripts/check-vault-image-contract.sh
@@ -65,6 +65,10 @@ grep -Fq 'COPY --from=builder --chown=0:0 --chmod=0555 /out/vault /usr/local/bin
   fail "Vault binary permissions or ownership are not locked down"
 grep -Fq 'COPY --chown=0:0 --chmod=0444 vault-server.hcl.tmpl /etc/vault/config.hcl.tmpl' "$dockerfile" ||
   fail "Vault template must remain root-owned and read-only"
+grep -Fq 'disable_clustering           = true' "$repo_root/vault-server.hcl.tmpl" ||
+  fail "the Cloud Run image must not advertise an unreachable cluster listener"
+grep -Fq 'ha_enabled = "true"' "$repo_root/vault-server.hcl.tmpl" ||
+  fail "the GCS storage backend must fence overlapping revisions with its HA lock"
 grep -Fq 'exec /usr/local/bin/vault server -config "$config_path"' "$entrypoint" ||
   fail "entrypoint does not execute the verified runtime binary"
 grep -Fq 'if [ "$#" -gt 0 ]; then' "$entrypoint" ||

--- a/scripts/check-vault-image-contract.sh
+++ b/scripts/check-vault-image-contract.sh
@@ -8,7 +8,7 @@ entrypoint="$repo_root/docker-entrypoint.sh"
 workflow="$repo_root/.github/workflows/vault-image.yml"
 ci_workflow="$repo_root/.github/workflows/lint-test.yml"
 release_workflow="$repo_root/.github/workflows/release.yml"
-shared_publisher_sha="578137212ead4ab4059e95df17fa30e9b7ac4aed"
+shared_publisher_sha="8e27d95846671a9e319f1900e86a488a1d4f39b3"
 
 fail() {
   printf 'Vault image contract: %s\n' "$*" >&2

--- a/scripts/check-vault-image-contract.sh
+++ b/scripts/check-vault-image-contract.sh
@@ -8,7 +8,7 @@ entrypoint="$repo_root/docker-entrypoint.sh"
 workflow="$repo_root/.github/workflows/vault-image.yml"
 ci_workflow="$repo_root/.github/workflows/lint-test.yml"
 release_workflow="$repo_root/.github/workflows/release.yml"
-shared_publisher_sha="8e27d95846671a9e319f1900e86a488a1d4f39b3"
+shared_publisher_sha="d5a29840172a53729c5999832534de65b7ba9587"
 
 fail() {
   printf 'Vault image contract: %s\n' "$*" >&2

--- a/scripts/check-vault-image-contract.sh
+++ b/scripts/check-vault-image-contract.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")/.." && pwd)"
+dockerfile="$repo_root/Dockerfile"
+entrypoint="$repo_root/docker-entrypoint.sh"
+workflow="$repo_root/.github/workflows/vault-image.yml"
+ci_workflow="$repo_root/.github/workflows/lint-test.yml"
+release_workflow="$repo_root/.github/workflows/release.yml"
+shared_publisher_sha="578137212ead4ab4059e95df17fa30e9b7ac4aed"
+
+fail() {
+  printf 'Vault image contract: %s\n' "$*" >&2
+  exit 1
+}
+
+for required_file in \
+  "$dockerfile" \
+  "$entrypoint" \
+  "$workflow" \
+  "$ci_workflow" \
+  "$release_workflow"; do
+  [[ -f "$required_file" ]] || fail "required file is missing: $required_file"
+done
+
+mapfile -t vault_versions < <(
+  sed -n 's/^ARG VAULT_VERSION=\([^[:space:]]\+\)$/\1/p' "$dockerfile" |
+    sort -u
+)
+[[ "${#vault_versions[@]}" -eq 1 ]] ||
+  fail "builder and runtime stages must use one exact VAULT_VERSION"
+vault_version="${vault_versions[0]}"
+[[ "$vault_version" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$ ]] ||
+  fail "VAULT_VERSION must be exact SemVer"
+
+image_revision="$(
+  sed -n 's/^ARG IMAGE_REVISION=\([1-9][0-9]*\)$/\1/p' "$dockerfile"
+)"
+[[ -n "$image_revision" ]] ||
+  fail "IMAGE_REVISION must be a positive integer"
+
+vault_commit="$(
+  sed -n 's/^ARG VAULT_COMMIT=\([0-9a-f]\{40\}\)$/\1/p' "$dockerfile"
+)"
+[[ -n "$vault_commit" ]] ||
+  fail "VAULT_COMMIT must be an exact upstream source commit"
+grep -Fq 'golang:1.26.5-bookworm@sha256:' "$dockerfile" ||
+  fail "Vault must be rebuilt with the pinned patched Go toolchain"
+grep -Fq 'git fetch --depth=1 origin "${VAULT_COMMIT}"' "$dockerfile" ||
+  fail "Dockerfile does not fetch the exact upstream Vault commit"
+grep -Fq 'test "$(git rev-parse HEAD)" = "${VAULT_COMMIT}"' "$dockerfile" ||
+  fail "Dockerfile does not verify the upstream Vault checkout"
+grep -Fq 'GOFLAGS=-buildvcs=false CGO_ENABLED=0 GOOS=linux GOARCH="${TARGETARCH}" BUILD_TAGS=ui ./scripts/build.sh' "$dockerfile" ||
+  fail "Dockerfile does not build the official UI-enabled Vault target without scanner-confusing automatic VCS metadata"
+grep -Fq 'COPY --from=builder --chown=0:0 --chmod=0444 /src/LICENSE /licenses/Vault-LICENSE' "$dockerfile" ||
+  fail "Vault source license is not preserved in the runtime image"
+grep -Fq 'USER 65532:65532' "$dockerfile" ||
+  fail "Vault runtime must use the dedicated non-root numeric identity"
+grep -Fq "apk add --no-cache 'ca-certificates=20260611-r0'" "$dockerfile" ||
+  fail "runtime packages must be version-pinned"
+grep -Fq 'chmod 0755 /etc/vault' "$dockerfile" ||
+  fail "root-owned Vault configuration directory must remain traversable"
+grep -Fq 'COPY --from=builder --chown=0:0 --chmod=0555 /out/vault /usr/local/bin/vault' "$dockerfile" ||
+  fail "Vault binary permissions or ownership are not locked down"
+grep -Fq 'COPY --chown=0:0 --chmod=0444 vault-server.hcl.tmpl /etc/vault/config.hcl.tmpl' "$dockerfile" ||
+  fail "Vault template must remain root-owned and read-only"
+grep -Fq 'exec /usr/local/bin/vault server -config "$config_path"' "$entrypoint" ||
+  fail "entrypoint does not execute the verified runtime binary"
+grep -Fq 'if [ "$#" -gt 0 ]; then' "$entrypoint" ||
+  fail "entrypoint does not expose its config-render smoke path"
+grep -Fq 'KMS_KEY_RING must be a Google Cloud KMS resource name' "$entrypoint" ||
+  fail "entrypoint does not validate the KMS key-ring name"
+grep -Fq 'KMS_CRYPTO_KEY must be a Google Cloud KMS resource name' "$entrypoint" ||
+  fail "entrypoint does not validate the KMS crypto-key name"
+grep -Fq 'KMS_KEY_RING must be at most 63 characters' "$entrypoint" ||
+  fail "entrypoint does not enforce the KMS key-ring length limit"
+grep -Fq 'KMS_CRYPTO_KEY must be at most 63 characters' "$entrypoint" ||
+  fail "entrypoint does not enforce the KMS crypto-key length limit"
+grep -Fq 'umask 077' "$entrypoint" ||
+  fail "rendered Vault configuration is not owner-only"
+
+grep -Fq 'workflow_run:' "$workflow" ||
+  fail "publication is not gated on the repository CI workflow"
+grep -Fq '      - edited' "$workflow" ||
+  fail "editing an image pull request title does not rerun release separation"
+grep -Fq '      - .github/workflows/lint-test.yml' "$workflow" ||
+  fail "changes to the image CI trust anchor do not run the image checks"
+grep -Fq '[[ "$PR_TITLE" == *"[skip-release]"* ]]' "$workflow" ||
+  fail "image changes can release the Terraform module"
+for eligibility_condition in \
+  '"$CI_CONCLUSION" == success' \
+  '"$CI_EVENT" == push' \
+  '"$CI_HEAD_BRANCH" == main' \
+  '"$CI_HEAD_REPOSITORY" == "$GITHUB_REPOSITORY"' \
+  '"$CI_WORKFLOW_PATH" == .github/workflows/lint-test.yml'; do
+  grep -Fq "$eligibility_condition" "$workflow" ||
+    fail "workflow-run eligibility is missing: $eligibility_condition"
+done
+grep -Fq "libops/.github/.github/workflows/build-push.yaml@${shared_publisher_sha}" "$workflow" ||
+  fail "publication does not use the reviewed immutable shared publisher"
+grep -Fq 'additional-gar-registry: us-docker.pkg.dev/libops-images/public' "$workflow" ||
+  fail "Cloud Run image is not published to the shared public GAR"
+grep -Fq 'GCLOUD_OIDC_POOL: ${{ secrets.GCLOUD_OIDC_POOL }}' "$workflow" ||
+  fail "publication does not use the shared WIF provider secret"
+grep -Fq 'GSA: ${{ secrets.GSA }}' "$workflow" ||
+  fail "publication does not use the shared publisher service account"
+grep -Fq 'expected-main-sha: ${{ github.event.workflow_run.head_sha }}' "$workflow" ||
+  fail "shared publication is not guarded by the exact current main commit"
+grep -Fq "eligible: \${{ steps.eligibility.outputs.eligible }}" "$workflow" ||
+  fail "workflow-run eligibility is not exposed to publication and result gating"
+grep -Fq "if: needs.authorize.outputs.eligible == 'true'" "$workflow" ||
+  fail "publication is not restricted to an eligible main push"
+grep -Fq 'if [[ "$ELIGIBLE_WORKFLOW_RUN" == true ]]; then' "$workflow" ||
+  fail "ineligible workflow completions are not handled as intentional no-ops"
+grep -Fq 'attempt-${GITHUB_RUN_ATTEMPT}' "$workflow" ||
+  fail "image publication tag can be overwritten by a workflow rerun"
+grep -Fq 'scan: true' "$workflow" ||
+  fail "published image scanning is disabled"
+grep -Fq 'sign: true' "$workflow" ||
+  fail "published image signing is disabled"
+
+if grep -Fq 'build-push.yaml@main' "$workflow" ||
+  grep -Fq 'secrets: inherit' "$workflow"; then
+  fail "workflow uses a mutable publisher or over-broad secret forwarding"
+fi
+
+grep -Fxq 'name: Terraform CI' "$ci_workflow" ||
+  fail "the triggering workflow name no longer matches the image workflow"
+ci_push_trigger="$(
+  awk '
+    /^  push:$/ {
+      in_push = 1
+      print
+      next
+    }
+    in_push && /^  [[:alnum:]_-]+:/ {
+      exit
+    }
+    in_push {
+      print
+    }
+  ' "$ci_workflow"
+)"
+grep -Fq '  push:' <<< "$ci_push_trigger" ||
+  fail "the triggering workflow no longer runs on pushes"
+grep -Fq '    branches:' <<< "$ci_push_trigger" ||
+  fail "the triggering workflow push is not branch-restricted"
+grep -Fq '      - main' <<< "$ci_push_trigger" ||
+  fail "the triggering workflow no longer runs on main"
+grep -Fq 'run: bash scripts/check-vault-image-contract.sh' "$ci_workflow" ||
+  fail "the triggering workflow no longer validates the image contract"
+
+for release_contract in \
+  'name: Classify merged change' \
+  'changed_files="$(' \
+  'gh api --paginate \' \
+  '.previous_filename // empty' \
+  'Dockerfile|docker-entrypoint.sh|vault-server.hcl.tmpl|scripts/check-vault-image-contract.sh|.github/workflows/lint-test.yml|.github/workflows/vault-image.yml)' \
+  'if: needs.classify.outputs.release-module == '\''true'\'''; do
+  grep -Fq "$release_contract" "$release_workflow" ||
+    fail "the module release workflow no longer classifies image-only changes: $release_contract"
+done
+
+if [[ "${1:-}" == "--print-tag" ]]; then
+  printf '%s-libops.%s\n' "$vault_version" "$image_revision"
+elif [[ "$#" -ne 0 ]]; then
+  fail "unsupported argument: $1"
+fi

--- a/vault-server.hcl.tmpl
+++ b/vault-server.hcl.tmpl
@@ -15,5 +15,7 @@ seal "gcpckms" {
 }
 
 storage "gcs" {
-  ha_enabled = "false"
+  # Use the GCS HA lock as a fencing boundary even when a deployment normally
+  # runs one instance. Cloud Run can briefly overlap revisions during rollout.
+  ha_enabled = "true"
 }


### PR DESCRIPTION
Adds a dedicated non-root multi-platform Vault 2.0.3 image with pinned upstream checksums, credential-free PR build/scan, exact post-CI GHCR+GAR publication, signing, immutable run-attempt tags, and release-boundary contracts. This PR must remain unmerged until the verified publisher WIF change is applied.