### PR TITLE
[skip-release] Restore applied publisher contract

### DIFF
--- a/.github/workflows/vault-image.yml
+++ b/.github/workflows/vault-image.yml
@@ -252,7 +252,7 @@ jobs:
     name: Publish Vault / GHCR and GAR
     if: needs.authorize.outputs.eligible == 'true'
     needs: authorize
-    uses: libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+    uses: libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     with:
       image: vault-server
       ref: ${{ github.event.workflow_run.head_sha }}
@@ -261,7 +261,7 @@ jobs:
       additional-gar-registry: us-docker.pkg.dev/libops-images/public
       scan: true
       sign: true
-      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@8e27d95846671a9e319f1900e86a488a1d4f39b3
+      certificate-identity: https://github.com/libops/.github/.github/workflows/build-push.yaml@d5a29840172a53729c5999832534de65b7ba9587
     secrets:
       GCLOUD_OIDC_POOL: ${{ secrets.GCLOUD_OIDC_POOL }}
       GSA: ${{ secrets.GSA }}

--- a/scripts/check-vault-image-contract.sh
+++ b/scripts/check-vault-image-contract.sh
@@ -8,7 +8,7 @@ entrypoint="$repo_root/docker-entrypoint.sh"
 workflow="$repo_root/.github/workflows/vault-image.yml"
 ci_workflow="$repo_root/.github/workflows/lint-test.yml"
 release_workflow="$repo_root/.github/workflows/release.yml"
-shared_publisher_sha="8e27d95846671a9e319f1900e86a488a1d4f39b3"
+shared_publisher_sha="d5a29840172a53729c5999832534de65b7ba9587"
 
 fail() {
   printf 'Vault image contract: %s\n' "$*" >&2


### PR DESCRIPTION
## Summary
- restore the cleanup-safe immutable shared publisher revision already authorized for Vault
- keep the signing certificate identity and contract guard on that exact revision

## Validation
- Vault image contract
- Terraform formatting
- actionlint
- git diff --check